### PR TITLE
Setup production logging

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -36,6 +36,7 @@ spec:
             path: /metrics
         args:
           - --enable-leader-election
+          - --log-level=debug
           - --log-json
         resources:
           limits:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
+	go.uber.org/zap v1.10.0
 	helm.sh/helm/v3 v3.2.4
 	k8s.io/api v0.18.4
 	k8s.io/apiextensions-apiserver v0.18.4


### PR DESCRIPTION
For production the log format is JSON, the timestamps format is ISO8601
and stack traces are logged when the level is set to debug.