### PR TITLE
Watch for releases at cluster level

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -13,6 +13,9 @@ spec:
     metadata:
       labels:
         app: helm-controller
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
     spec:
       terminationGracePeriodSeconds: 10
       containers:
@@ -25,11 +28,6 @@ spec:
         ports:
           - containerPort: 8080
             name: http-prom
-        env:
-          - name: RUNTIME_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
         livenessProbe:
           httpGet:
             port: http-prom
@@ -40,8 +38,8 @@ spec:
           - --log-json
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 64Mi


### PR DESCRIPTION
Remove namespace watch restriction, this allows Helm controller to act on HelmRelease at cluster level.