### PR TITLE
Support KeepHistory flag for Helm uninstall action

### DIFF
--- a/api/v2alpha1/helmrelease_types.go
+++ b/api/v2alpha1/helmrelease_types.go
@@ -317,6 +317,11 @@ type Uninstall struct {
 	// DisableHooks prevents hooks from running during the Helm rollback action.
 	// +optional
 	DisableHooks bool `json:"disableHooks,omitempty"`
+
+	// KeepHistory tells Helm to remove all associated resources and mark the release as
+	// deleted, but retain the release history.
+	// +optional
+	KeepHistory bool `json:"keepHistory,omitempty"`
 }
 
 // GetTimeout returns the configured timeout for the Helm uninstall action,

--- a/config/crd/bases/helm.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.fluxcd.io_helmreleases.yaml
@@ -208,6 +208,10 @@ spec:
                   description: DisableHooks prevents hooks from running during the
                     Helm rollback action.
                   type: boolean
+                keepHistory:
+                  description: KeepHistory tells Helm to remove all associated resources
+                    and mark the release as deleted, but retain the release history.
+                  type: boolean
                 timeout:
                   description: Timeout is the time to wait for any individual Kubernetes
                     operation (like Jobs for hooks) during the performance of a Helm

--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -555,6 +555,7 @@ func uninstall(cfg *action.Configuration, hr v2.HelmRelease) error {
 	uninstall := action.NewUninstall(cfg)
 	uninstall.Timeout = hr.Spec.Uninstall.GetTimeout(hr.GetTimeout()).Duration
 	uninstall.DisableHooks = hr.Spec.Uninstall.DisableHooks
+	uninstall.KeepHistory = hr.Spec.Uninstall.KeepHistory
 
 	_, err := uninstall.Run(hr.GetReleaseName())
 	return err

--- a/docs/api/helmrelease.md
+++ b/docs/api/helmrelease.md
@@ -1126,6 +1126,19 @@ bool
 <p>DisableHooks prevents hooks from running during the Helm rollback action.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>keepHistory</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KeepHistory tells Helm to remove all associated resources and mark the release as
+deleted, but retain the release history.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>

--- a/docs/spec/v2alpha1/helmreleases.md
+++ b/docs/spec/v2alpha1/helmreleases.md
@@ -233,6 +233,11 @@ type Uninstall struct {
 	// DisableHooks prevents hooks from running during the Helm rollback action.
 	// +optional
 	DisableHooks bool `json:"disableHooks,omitempty"`
+
+	// KeepHistory tells Helm to remove all associated resources and mark the release
+	// as deleted, but retain the release history.
+	// +optional
+	KeepHistory bool `json:"keepHistory,omitempty"`
 }
 ```
 


### PR DESCRIPTION
This is the companion to 'Install.Replace' (and the only missing option flag).