### PR TITLE
Uninstall fixes

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -356,10 +356,12 @@ func (r *HelmReleaseReconciler) release(log logr.Logger, hr v2.HelmRelease, sour
 
 	// Run uninstall
 	if v2.ShouldUninstall(hr, releaseRevision) {
+		success = false
 		if err = uninstall(cfg, hr); err != nil {
 			v2.SetHelmReleaseCondition(&hr, v2.UninstallCondition, corev1.ConditionFalse, v2.UninstallFailedReason, err.Error())
 			r.event(hr, source.GetArtifact().Revision, recorder.EventSeverityError, fmt.Sprintf("Helm uninstall failed: %s", err.Error()))
 		} else {
+			releaseRevision = 0
 			v2.SetHelmReleaseCondition(&hr, v2.UninstallCondition, corev1.ConditionTrue, v2.UninstallSucceededReason, "Helm uninstall succeeded")
 			r.event(hr, source.GetArtifact().Revision, recorder.EventSeverityInfo, "Helm uninstall succeeded")
 		}


### PR DESCRIPTION
* Ensure Status.LastReleaseRevision is 0 after uninstall. This
  could be nil instead, but since 0 is never a valid release revision,
  it seems sufficient.
* Ensure uninstall leads to ready condition being false. This has
  no effect now since uninstall is only triggered on install failure,
  but will once other triggers (such as test failure) are supported.