### PR TITLE
Fix Helm chart update

### DIFF
--- a/config/testdata/dependencies/helmrelease-backend.yaml
+++ b/config/testdata/dependencies/helmrelease-backend.yaml
@@ -9,7 +9,7 @@ spec:
     version: '^4.0.0'
     sourceRef:
       kind: HelmRepository
-      name: podinfo
+      name: webapp
     interval: 1m
   test:
     enable: true

--- a/config/testdata/dependencies/helmrelease-frontend.yaml
+++ b/config/testdata/dependencies/helmrelease-frontend.yaml
@@ -9,7 +9,7 @@ spec:
     version: '^4.0.0'
     sourceRef:
       kind: HelmRepository
-      name: podinfo
+      name: webapp
     interval: 1m
   dependsOn:
     - backend

--- a/config/testdata/dependencies/helmrepository.yaml
+++ b/config/testdata/dependencies/helmrepository.yaml
@@ -1,7 +1,7 @@
 apiVersion: source.fluxcd.io/v1alpha1
 kind: HelmRepository
 metadata:
-  name: podinfo
+  name: webapp
 spec:
   interval: 1m
   url: https://stefanprodan.github.io/podinfo

--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -252,8 +252,9 @@ func (r *HelmReleaseReconciler) reconcileChart(ctx context.Context, hr *v2.HelmR
 		hr.Status.HelmChart = chartName.String()
 		return nil, false, nil
 	case helmChartRequiresUpdate(*hr, helmChart):
+		r.Log.Info("chart diverged from template", strings.ToLower(sourcev1.HelmChartKind), chartName.String())
 		helmChart.Spec = hc.Spec
-		if err = r.Client.Update(ctx, hc); err != nil {
+		if err = r.Client.Update(ctx, &helmChart); err != nil {
 			return nil, false, err
 		}
 		hr.Status.HelmChart = chartName.String()
@@ -483,7 +484,7 @@ func helmChartRequiresUpdate(hr v2.HelmRelease, chart sourcev1.HelmChart) bool {
 		return true
 	case template.Version != chart.Spec.Version:
 		return true
-	case template.SourceRef.Name != chart.Spec.Name:
+	case template.SourceRef.Name != chart.Spec.HelmRepositoryRef.Name:
 		return true
 	case template.GetInterval(hr.Spec.Interval) != chart.Spec.Interval:
 		return true


### PR DESCRIPTION
Re-fix #31 

Before:

```
$ tk create hr sealed-secrets --interval=1h --release-name=sealed-secrets --target-namespace=gitops-system --source=stable --chart-name=sealed-secrets --chart-version="^1.10.0"

✚ generating release
► applying release
✔ release created
◎ waiting for reconciliation
✗ chart reconciliation failed: helmcharts.source.fluxcd.io "gitops-system-sealed-secrets" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
```

After:

```
 $ tk create hr sealed-secrets --interval=1h --release-name=sealed-secrets --target-namespace=gitops-system --source=stable --chart-name=sealed-secrets --chart-version="^1.10.0"

✚ generating release
► applying release
✔ release created
◎ waiting for reconciliation
✔ release sealed-secrets is ready
✔ applied revision 1.10.3
```