### PR TITLE
Rename conditions to describe the current state

### DIFF
--- a/api/v2alpha1/condition_types.go
+++ b/api/v2alpha1/condition_types.go
@@ -51,20 +51,20 @@ const (
 	// ReadyCondition represents the fact that the HelmRelease has been successfully reconciled.
 	ReadyCondition string = "Ready"
 
-	// InstallCondition represents the fact that the HelmRelease has been successfully installed.
-	InstallCondition string = "Install"
+	// InstalledCondition represents the fact that the HelmRelease has been successfully installed.
+	InstalledCondition string = "Installed"
 
-	// UpgradeCondition represents the fact that the HelmRelease has been successfully upgraded.
-	UpgradeCondition string = "Upgrade"
+	// UpgradedCondition represents the fact that the HelmRelease has been successfully upgraded.
+	UpgradedCondition string = "Upgraded"
 
-	// TestCondition represents the fact that the HelmRelease has been successfully tested.
-	TestCondition string = "Test"
+	// TestedCondition represents the fact that the HelmRelease has been successfully tested.
+	TestedCondition string = "Tested"
 
-	// RollbackCondition represents the fact that the HelmRelease has been successfully rolled back.
-	RollbackCondition string = "Rollback"
+	// RolledBackCondition represents the fact that the HelmRelease has been successfully rolled back.
+	RolledBackCondition string = "RolledBack"
 
-	// UninstallCondition represents the fact that the HelmRelease has been successfully uninstalled.
-	UninstallCondition string = "Uninstall"
+	// UninstalledCondition represents the fact that the HelmRelease has been successfully uninstalled.
+	UninstalledCondition string = "Uninstall"
 )
 
 const (

--- a/api/v2alpha1/helmrelease_types.go
+++ b/api/v2alpha1/helmrelease_types.go
@@ -449,7 +449,7 @@ func ShouldUpgrade(hr HelmRelease, revision string, releaseRevision int) bool {
 func ShouldTest(hr HelmRelease) bool {
 	if hr.Spec.Test.Enable {
 		for _, c := range hr.Status.Conditions {
-			if c.Status == corev1.ConditionTrue && (c.Type == InstallCondition || c.Type == UpgradeCondition) {
+			if c.Status == corev1.ConditionTrue && (c.Type == InstalledCondition || c.Type == UpgradedCondition) {
 				return true
 			}
 		}
@@ -464,7 +464,7 @@ func ShouldRollback(hr HelmRelease, releaseRevision int) bool {
 			return false
 		}
 		for _, c := range hr.Status.Conditions {
-			if c.Type == UpgradeCondition && c.Status == corev1.ConditionFalse {
+			if c.Type == UpgradedCondition && c.Status == corev1.ConditionFalse {
 				return true
 			}
 		}
@@ -478,7 +478,7 @@ func ShouldUninstall(hr HelmRelease, releaseRevision int) bool {
 		return false
 	}
 	for _, c := range hr.Status.Conditions {
-		if c.Type == InstallCondition && c.Status == corev1.ConditionFalse {
+		if c.Type == InstalledCondition && c.Status == corev1.ConditionFalse {
 			return true
 		}
 	}

--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -308,25 +308,25 @@ func (r *HelmReleaseReconciler) release(log logr.Logger, hr v2.HelmRelease, sour
 	success := true
 	if errors.Is(err, driver.ErrNoDeployedReleases) {
 		rel, err = install(cfg, loadedChart, hr)
-		r.handleHelmActionResult(hr, source, err, "install", v2.InstallCondition, v2.InstallSucceededReason, v2.InstallFailedReason)
+		r.handleHelmActionResult(hr, source, err, "install", v2.InstalledCondition, v2.InstallSucceededReason, v2.InstallFailedReason)
 		success = err == nil
 	} else if v2.ShouldUpgrade(hr, source.GetArtifact().Revision, rel.Version) {
 		rel, err = upgrade(cfg, loadedChart, hr)
-		r.handleHelmActionResult(hr, source, err, "upgrade", v2.UpgradeCondition, v2.UpgradeSucceededReason, v2.UpgradeFailedReason)
+		r.handleHelmActionResult(hr, source, err, "upgrade", v2.UpgradedCondition, v2.UpgradeSucceededReason, v2.UpgradeFailedReason)
 		success = err == nil
 	}
 
 	// Run tests
 	if v2.ShouldTest(hr) {
 		rel, err = test(cfg, hr)
-		r.handleHelmActionResult(hr, source, err, "test", v2.TestCondition, v2.TestSucceededReason, v2.TestFailedReason)
+		r.handleHelmActionResult(hr, source, err, "test", v2.TestedCondition, v2.TestSucceededReason, v2.TestFailedReason)
 	}
 
 	// Run rollback
 	if rel != nil && v2.ShouldRollback(hr, rel.Version) {
 		success = false
 		err = rollback(cfg, hr)
-		r.handleHelmActionResult(hr, source, err, "rollback", v2.RollbackCondition, v2.RollbackSucceededReason, v2.RollbackFailedReason)
+		r.handleHelmActionResult(hr, source, err, "rollback", v2.RolledBackCondition, v2.RollbackSucceededReason, v2.RollbackFailedReason)
 	}
 
 	// Determine release number after action runs
@@ -342,7 +342,7 @@ func (r *HelmReleaseReconciler) release(log logr.Logger, hr v2.HelmRelease, sour
 		if err == nil {
 			releaseRevision = 0
 		}
-		r.handleHelmActionResult(hr, source, err, "uninstall", v2.UninstallCondition, v2.UninstallSucceededReason, v2.UninstallFailedReason)
+		r.handleHelmActionResult(hr, source, err, "uninstall", v2.UninstalledCondition, v2.UninstallSucceededReason, v2.UninstallFailedReason)
 	}
 
 	if !success {

--- a/docs/spec/v2alpha1/helmreleases.md
+++ b/docs/spec/v2alpha1/helmreleases.md
@@ -248,20 +248,20 @@ const (
 	// ReadyCondition represents the fact that the HelmRelease has been successfully reconciled.
 	ReadyCondition string = "Ready"
 
-	// InstallCondition represents the fact that the HelmRelease has been successfully installed.
-	InstallCondition string = "Install"
+	// InstalledCondition represents the fact that the HelmRelease has been successfully installed.
+	InstalledCondition string = "Installed"
 
-	// UpgradeCondition represents the fact that the HelmRelease has been successfully upgraded.
-	UpgradeCondition string = "Upgrade"
+	// UpgradedCondition represents the fact that the HelmRelease has been successfully upgraded.
+	UpgradedCondition string = "Upgraded"
 
-	// TestCondition represents the fact that the HelmRelease has been successfully tested.
-	TestCondition string = "Test"
+	// TestedCondition represents the fact that the HelmRelease has been successfully tested.
+	TestedCondition string = "Tested"
 
-	// RollbackCondition represents the fact that the HelmRelease has been successfully rolled back.
-	RollbackCondition string = "Rollback"
+	// RolledBackCondition represents the fact that the HelmRelease has been successfully rolled back.
+	RolledBackCondition string = "RolledBack"
 
-	// UninstallCondition represents the fact that the HelmRelease has been successfully uninstalled.
-	UninstallCondition string = "Uninstall"
+	// UninstalledCondition represents the fact that the HelmRelease has been successfully uninstalled.
+	UninstalledCondition string = "Uninstalled"
 )
 ```
 


### PR DESCRIPTION
As "condition type names should describe the current observed state of
the resource, rather than describing the current state transitions".

(H/T @seaneagan https://github.com/fluxcd/toolkit/discussions/119#discussioncomment-40966)