### PR TITLE
Support multi-arch buildx docker images

### DIFF
--- a/.github/workflows/release-multi-arch.yml
+++ b/.github/workflows/release-multi-arch.yml
@@ -1,0 +1,38 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: latest
+
+      - name: Login to GitHub Docker Registry
+        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKER_FLUXCD_USER }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
+
+      - name: Build Container Image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --tag fluxcd/helm-controller-multi-arch:latest \
+            --tag fluxcd/helm-controller-multi-arch:${{ steps.get_version.outputs.VERSION }} \
+            -f Dockerfile \
+            . --push
+


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description
- Updating Dockerfile to ensure the go binary is compiled for the target architecture platform.
- Adding a test workflow for pushing a release `-multi-arch` suffix image that doesn't break the existing AMD64 image variant.

# TODO
- Discuss other resources that need to be multi-arch in Fluxv2
- Phase `-multi-arch` variant to replace existing.

**EDIT: Just noticed #68 which I think we can slightly improve to use `buildx` and tweak the Dockerfile to accommodate additional architectures in the future on top of arm/amd
