### PR TITLE
Refactor status API

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -84,7 +84,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Installed=="False" and .Ready=="False"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="False" and .Ready=="False"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -107,7 +107,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Installed=="True" and .Tested=="False" and .Ready=="False"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="False" and .TestSuccess=="False" and .Ready=="False"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -130,7 +130,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Installed=="True" and .Tested=="False" and .Ready=="True"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="True" and .TestSuccess=="False" and .Ready=="True"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -153,7 +153,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Installed=="False" and .Ready=="False" and .Uninstalled=="True"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="False" and .Ready=="False" and .Remediated=="True"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -176,7 +176,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.installFailures == 2 and ( .status.conditions | map( { (.type): .status } ) | add | .Installed=="False" and .Ready=="False" )' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.installFailures == 2 and ( .status.conditions | map( { (.type): .status } ) | add | .Released=="False" and .Ready=="False" )' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -199,7 +199,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/install.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Installed=="True" and .Ready=="True"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="True" and .Ready=="True"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -220,7 +220,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/upgrade.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Upgraded=="False" and .Ready=="False"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="False" and .Ready=="False"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -243,7 +243,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/install.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Installed=="True" and .Ready=="True"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="True" and .Ready=="True"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -264,7 +264,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/upgrade.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Upgraded=="True" and .Tested=="False" and .Ready=="False"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="False" and .TestSuccess=="False" and .Ready=="False"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -287,7 +287,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/install.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Installed=="True" and .Ready=="True"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="True" and .Ready=="True"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -308,7 +308,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/upgrade.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Upgraded=="False" and .Ready=="False" and .RolledBack=="True"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="False" and .Ready=="False" and .Remediated=="True"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -336,7 +336,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/install.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Installed=="True" and .Ready=="True"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="True" and .Ready=="True"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -357,7 +357,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/upgrade.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.upgradeFailures == 2 and ( .status.conditions | map( { (.type): .status } ) | add | .Upgraded=="False" and .Ready=="False" and .RolledBack=="True" )' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.upgradeFailures == 2 and ( .status.conditions | map( { (.type): .status } ) | add | .Released=="False" and .Ready=="False" )' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -385,7 +385,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/install.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Installed=="True" and .Ready=="True"' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.conditions | map( { (.type): .status } ) | add | .Released=="True" and .Ready=="True"' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -412,7 +412,7 @@ jobs:
           kubectl -n helm-system apply -f config/testdata/$test_name/upgrade.yaml
           echo -n ">>> Waiting for expected conditions"
           count=0
-          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.upgradeFailures == 1 and .status.installFailures == 1 and ( .status.conditions | map( { (.type): .status } ) | add | .Upgraded=="False" and .Uninstalled=="True" and .Installed=="False" and .Ready=="False" )' )" ]; do
+          until [ 'true' == "$( kubectl -n helm-system get helmrelease/$test_name -o json | jq '.status.upgradeFailures == 1 and .status.installFailures == 1 and ( .status.conditions | map( { (.type): .status } ) | add | .Released=="False" and .Ready=="False" )' )" ]; do
             echo -n '.'
             sleep 5
             count=$((count + 1))
@@ -449,6 +449,6 @@ jobs:
           kubectl -n helm-system get helmcharts -oyaml
           kubectl -n helm-system get helmreleases -oyaml
           kubectl -n helm-system get all
-          helm ls -n helm-system
+          helm ls -n helm-system --all
           kubectl -n helm-system logs deploy/source-controller
           kubectl -n helm-system logs deploy/helm-controller

--- a/api/v2alpha1/condition_types.go
+++ b/api/v2alpha1/condition_types.go
@@ -51,20 +51,14 @@ const (
 	// ReadyCondition represents the fact that the HelmRelease has been successfully reconciled.
 	ReadyCondition string = "Ready"
 
-	// InstalledCondition represents the fact that the HelmRelease has been successfully installed.
-	InstalledCondition string = "Installed"
+	// ReleasedCondition represents the fact that the HelmRelease has been successfully released.
+	ReleasedCondition string = "Released"
 
-	// UpgradedCondition represents the fact that the HelmRelease has been successfully upgraded.
-	UpgradedCondition string = "Upgraded"
+	// TestSuccessCondition represents the fact that the tests for the HelmRelease are succeeding.
+	TestSuccessCondition string = "TestSuccess"
 
-	// TestedCondition represents the fact that the HelmRelease has been successfully tested.
-	TestedCondition string = "Tested"
-
-	// RolledBackCondition represents the fact that the HelmRelease has been successfully rolled back.
-	RolledBackCondition string = "RolledBack"
-
-	// UninstalledCondition represents the fact that the HelmRelease has been successfully uninstalled.
-	UninstalledCondition string = "Uninstalled"
+	// RemediatedCondition represents the fact that the HelmRelease has been successfully remediated.
+	RemediatedCondition string = "Remediated"
 )
 
 const (
@@ -86,11 +80,11 @@ const (
 	// UpgradeFailedReason represents the fact that the Helm upgrade for the HelmRelease failed.
 	UpgradeFailedReason string = "UpgradeFailed"
 
-	// TestSucceededReason represents the fact that the Helm test for the HelmRelease succeeded.
+	// TestSucceededReason represents the fact that the Helm tests for the HelmRelease succeeded.
 	TestSucceededReason string = "TestSucceeded"
 
-	// TestFailedReason represents the fact that the Helm test for the HelmRelease failed.
-	TestFailedReason string = "TestFailed"
+	// TestFailedReason represents the fact that the Helm tests for the HelmRelease failed.
+	TestFailedReason string = "TestsFailed"
 
 	// RollbackSucceededReason represents the fact that the Helm rollback for the HelmRelease succeeded.
 	RollbackSucceededReason string = "RollbackSucceeded"

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -436,10 +436,6 @@ spec:
                 description: ObservedGeneration is the last observed generation.
                 format: int64
                 type: integer
-              observedStateReconciled:
-                description: ObservedStateReconciled represents whether the observed
-                  state has been successfully reconciled.
-                type: boolean
               upgradeFailures:
                 description: UpgradeFailures is the upgrade failure count against
                   the latest observed state. It is reset after a successful reconciliation.

--- a/docs/api/helmrelease.md
+++ b/docs/api/helmrelease.md
@@ -895,18 +895,6 @@ int64
 </tr>
 <tr>
 <td>
-<code>observedStateReconciled</code><br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ObservedStateReconciled represents whether the observed state has been successfully reconciled.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>lastObservedTime</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">


### PR DESCRIPTION
    Refactor status API
    
    This removes:
    
    - Installed, Upgraded, RolledBack, and Uninstalled status conditions
      since they did not represent current state, but rather actions
      taken, which are already recorded by events.
    - status.observedStateReconciled since it solved the problem of
      remembering past release (install/upgrade/test) success, but not
      past release failures, after other subsequent failures such as
      dependency failures, k8s API failures, etc.
    
    This adds:
    
    - Remediated status condition which records whether the release is
      currently in a remediated state. It is used to prevent release retries
      after remediation failures. We were previously not doing this for
      rollback failures.
    - Released status condition which records whether the current state
      has been successfully released (install/upgrade/test). This is used to
      remember the last release attempt status, regardless of any subsequent
      other failures such as dependency failures, k8s API failures, etc.
    
    This renames:
    
    - Tested > TestSuccess status condition, for forward compatibility
      with interval based helm tests.

xRef: https://github.com/fluxcd/toolkit/discussions/179
