### PR TITLE
Include PATCH rule for events in manager-role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ dev-cleanup: manifests
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role paths="./..." output:crd:artifacts:config="config/crd/bases"
 	cd api; $(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role paths="./..." output:crd:artifacts:config="../config/crd/bases"
 
 # Generate API reference documentation

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,13 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - helm.toolkit.fluxcd.io
   resources:
   - helmreleases

--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -82,6 +82,7 @@ func (c ConditionError) Error() string {
 
 // +kubebuilder:rbac:groups=helm.toolkit.fluxcd.io,resources=helmreleases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=helm.toolkit.fluxcd.io,resources=helmreleases/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *HelmReleaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()


### PR DESCRIPTION
During high custom resource count / low interval tests, I was greated
with a `cannot patch resource "events"` message. This happened due to
event compaction, where it will perform a patch instead of a create.
By giving the role the permission to do so this should no longer pose
a problem.