### PR TITLE
Support optional values references

### DIFF
--- a/api/v2alpha1/reference_types.go
+++ b/api/v2alpha1/reference_types.go
@@ -67,6 +67,12 @@ type ValuesReference struct {
 	// Defaults to 'None', which results in the values getting merged at the root.
 	// +optional
 	TargetPath string `json:"targetPath,omitempty"`
+
+	// Optional marks this ValuesReference as optional. When set, a not found
+	// error for the values reference is ignored, but any ValuesKey, TargetPath or
+	// transient error will still result in a reconciliation failure.
+	// +optional
+	Optional bool `json:"optional,omitempty"`
 }
 
 // GetValuesKey returns the defined ValuesKey, or the default ('values.yaml').

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -368,6 +368,12 @@ spec:
                       maxLength: 253
                       minLength: 1
                       type: string
+                    optional:
+                      description: Optional marks this ValuesReference as optional.
+                        When set, a not found error for the values reference is ignored,
+                        but any ValuesKey, TargetPath or transient error will still
+                        result in a reconciliation failure.
+                      type: boolean
                     targetPath:
                       description: TargetPath is the YAML dot notation path the value
                         should be merged at. When set, the ValuesKey is expected to

--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -525,6 +525,10 @@ func (r *HelmReleaseReconciler) composeValues(ctx context.Context, hr v2.HelmRel
 			var resource corev1.ConfigMap
 			if err := r.Get(ctx, namespacedName, &resource); err != nil {
 				if apierrors.IsNotFound(err) {
+					if v.Optional {
+						r.Log.Info("could not find optional %s '%s'", v.Kind, namespacedName)
+						continue
+					}
 					return nil, fmt.Errorf("could not find %s '%s'", v.Kind, namespacedName)
 				}
 				return nil, err
@@ -538,6 +542,10 @@ func (r *HelmReleaseReconciler) composeValues(ctx context.Context, hr v2.HelmRel
 			var resource corev1.Secret
 			if err := r.Get(ctx, namespacedName, &resource); err != nil {
 				if apierrors.IsNotFound(err) {
+					if v.Optional {
+						r.Log.Info("could not find optional %s '%s'", v.Kind, namespacedName)
+						continue
+					}
 					return nil, fmt.Errorf("could not find %s '%s'", v.Kind, namespacedName)
 				}
 				return nil, err

--- a/docs/api/helmrelease.md
+++ b/docs/api/helmrelease.md
@@ -1722,6 +1722,20 @@ When set, the ValuesKey is expected to be a single flat value.
 Defaults to &lsquo;None&rsquo;, which results in the values getting merged at the root.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>optional</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Optional marks this ValuesReference as optional. When set, a not found
+error for the values reference is ignored, but any ValuesKey, TargetPath or
+transient error will still result in a reconciliation failure.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>


### PR DESCRIPTION
This commit adds support for optional values references, as discussions
have brought to light that there are some valid use cases in which
having this option is desirable. For example to allow a user to extend
behaviour at a later date with their own repository without modifying
the HelmRelease object.

When a values reference is marked as optional, not found errors for the
value reference are ignored, but any ValuesKey, TargetPath or transient
error will still result in a reconciliation failure.

Ref: https://github.com/fluxcd/helm-controller/issues/42#issuecomment-693620588