### PR TITLE
Documentation improvements

### DIFF
--- a/api/v2alpha1/condition_types.go
+++ b/api/v2alpha1/condition_types.go
@@ -53,7 +53,7 @@ const (
 
 	// TestFailedReason represents the fact that the Helm tests for the HelmRelease
 	// failed.
-	TestFailedReason string = "TestsFailed"
+	TestFailedReason string = "TestFailed"
 
 	// RollbackSucceededReason represents the fact that the Helm rollback for the
 	// HelmRelease succeeded.

--- a/api/v2alpha1/condition_types.go
+++ b/api/v2alpha1/condition_types.go
@@ -18,16 +18,16 @@ package v2alpha1
 
 const (
 	// ReleasedCondition represents the status of the last release attempt
-	// (install/upgrade/test) against the current state.
+	// (install/upgrade/test) against the latest desired state.
 	ReleasedCondition string = "Released"
 
 	// TestSuccessCondition represents the status of the last test attempt against
-	// the current state.
+	// the latest desired state.
 	TestSuccessCondition string = "TestSuccess"
 
 	// RemediatedCondition represents the status of the last remediation attempt
 	// (uninstall/rollback) due to a failure of the last release attempt against the
-	// current state.
+	// latest desired state.
 	RemediatedCondition string = "Remediated"
 )
 

--- a/api/v2alpha1/condition_types.go
+++ b/api/v2alpha1/condition_types.go
@@ -17,16 +17,17 @@ limitations under the License.
 package v2alpha1
 
 const (
-	// ReleasedCondition represents the fact that the HelmRelease has been
-	// successfully released.
+	// ReleasedCondition represents the status of the last release attempt
+	// (install/upgrade/test) against the current state.
 	ReleasedCondition string = "Released"
 
-	// TestSuccessCondition represents the fact that the tests for the HelmRelease
-	// are succeeding.
+	// TestSuccessCondition represents the status of the last test attempt against
+	// the current state.
 	TestSuccessCondition string = "TestSuccess"
 
-	// RemediatedCondition represents the fact that the HelmRelease has been
-	// successfully remediated.
+	// RemediatedCondition represents the status of the last remediation attempt
+	// (uninstall/rollback) due to a failure of the last release attempt against the
+	// current state.
 	RemediatedCondition string = "Remediated"
 )
 

--- a/api/v2alpha1/helmrelease_types.go
+++ b/api/v2alpha1/helmrelease_types.go
@@ -33,7 +33,7 @@ import (
 const HelmReleaseKind = "HelmRelease"
 const HelmReleaseFinalizer = "finalizers.fluxcd.io"
 
-// HelmReleaseSpec defines the desired state of a Helm Release.
+// HelmReleaseSpec defines the desired state of a Helm release.
 type HelmReleaseSpec struct {
 	// Chart defines the template of the v1alpha1.HelmChart that should be created
 	// for this HelmRelease.
@@ -500,6 +500,7 @@ const (
 	// RollbackRemediationStrategy represents a Helm remediation strategy of Helm
 	// rollback.
 	RollbackRemediationStrategy RemediationStrategy = "rollback"
+
 	// UninstallRemediationStrategy represents a Helm remediation strategy of Helm
 	// uninstall.
 	UninstallRemediationStrategy RemediationStrategy = "uninstall"
@@ -639,17 +640,17 @@ type HelmReleaseStatus struct {
 	// +optional
 	HelmChart string `json:"helmChart,omitempty"`
 
-	// Failures is the reconciliation failure count against the latest observed
+	// Failures is the reconciliation failure count against the latest desired
 	// state. It is reset after a successful reconciliation.
 	// +optional
 	Failures int64 `json:"failures,omitempty"`
 
-	// InstallFailures is the install failure count against the latest observed
+	// InstallFailures is the install failure count against the latest desired
 	// state. It is reset after a successful reconciliation.
 	// +optional
 	InstallFailures int64 `json:"installFailures,omitempty"`
 
-	// UpgradeFailures is the upgrade failure count against the latest observed
+	// UpgradeFailures is the upgrade failure count against the latest desired
 	// state. It is reset after a successful reconciliation.
 	// +optional
 	UpgradeFailures int64 `json:"upgradeFailures,omitempty"`

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -429,7 +429,7 @@ spec:
                 type: array
               failures:
                 description: Failures is the reconciliation failure count against
-                  the latest observed state. It is reset after a successful reconciliation.
+                  the latest desired state. It is reset after a successful reconciliation.
                 format: int64
                 type: integer
               helmChart:
@@ -438,7 +438,7 @@ spec:
                 type: string
               installFailures:
                 description: InstallFailures is the install failure count against
-                  the latest observed state. It is reset after a successful reconciliation.
+                  the latest desired state. It is reset after a successful reconciliation.
                 format: int64
                 type: integer
               lastAppliedRevision:
@@ -467,7 +467,7 @@ spec:
                 type: integer
               upgradeFailures:
                 description: UpgradeFailures is the upgrade failure count against
-                  the latest observed state. It is reset after a successful reconciliation.
+                  the latest desired state. It is reset after a successful reconciliation.
                 format: int64
                 type: integer
             type: object

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -46,7 +46,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: HelmReleaseSpec defines the desired state of a Helm Release.
+            description: HelmReleaseSpec defines the desired state of a Helm release.
             properties:
               chart:
                 description: Chart defines the template of the v1alpha1.HelmChart

--- a/docs/api/helmrelease.md
+++ b/docs/api/helmrelease.md
@@ -564,7 +564,7 @@ relative path in the SourceRef. Ignored when omitted.</p>
 (<em>Appears on:</em>
 <a href="#helm.toolkit.fluxcd.io/v2alpha1.HelmRelease">HelmRelease</a>)
 </p>
-<p>HelmReleaseSpec defines the desired state of a Helm Release.</p>
+<p>HelmReleaseSpec defines the desired state of a Helm release.</p>
 <div class="md-typeset__scrollwrap">
 <div class="md-typeset__table">
 <table>
@@ -914,7 +914,7 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>Failures is the reconciliation failure count against the latest observed
+<p>Failures is the reconciliation failure count against the latest desired
 state. It is reset after a successful reconciliation.</p>
 </td>
 </tr>
@@ -927,7 +927,7 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>InstallFailures is the install failure count against the latest observed
+<p>InstallFailures is the install failure count against the latest desired
 state. It is reset after a successful reconciliation.</p>
 </td>
 </tr>
@@ -940,7 +940,7 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>UpgradeFailures is the upgrade failure count against the latest observed
+<p>UpgradeFailures is the upgrade failure count against the latest desired
 state. It is reset after a successful reconciliation.</p>
 </td>
 </tr>

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,11 +1,11 @@
 # Helm Controller
 
-The Helm Controller is a Kubernetes controller, allowing one to declaratively manage Helm chart
-releases with Kubernetes manifests.
+The Helm Controller is a [Kubernetes operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/),
+allowing one to declaratively manage Helm chart releases with Kubernetes manifests.
 
 ## Motivation
 
-The main goal is to provide an automated controller that can perform Helm actions (e.g.
+The main goal is to provide an automated operator that can perform Helm actions (e.g.
 install, upgrade, uninstall, rollback, test) and continuously reconcile the state of Helm releases.
 
 When provisioning a new cluster, one may wish to install Helm releases in a specific order, for
@@ -17,7 +17,7 @@ and this chart needs to be installed first.
 When dealing with an incident, one may wish to suspend the reconciliation of some Helm releases,
 without having to stop the reconciler and affect the whole cluster.
 
-When operating a cluster, different teams may wish to receive notification about the status of
+When operating a cluster, different teams may wish to receive notifications about the status of
 their Helm releases. For example, the on-call team would receive alerts about all failures in
 the prod namespace, while the frontend team may wish to be alerted when a new version of the
 frontend chart was released, no matter the namespace.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,12 +1,12 @@
 # Helm Controller
 
-The Helm Controller is a Kubernetes operator, allowing one to declaratively manage Helm chart
+The Helm Controller is a Kubernetes controller, allowing one to declaratively manage Helm chart
 releases with Kubernetes manifests.
 
 ## Motivation
 
-The main goal is to provide an automated operator that can perform Helm actions (e.g.
-install, upgrade, rollback, test) and continuously reconcile the state of Helm releases.
+The main goal is to provide an automated controller that can perform Helm actions (e.g.
+install, upgrade, uninstall, rollback, test) and continuously reconcile the state of Helm releases.
 
 When provisioning a new cluster, one may wish to install Helm releases in a specific order, for
 example because one relies on a service mesh admission controller managed by a `HelmRelease` and
@@ -34,7 +34,7 @@ actions that should be (conditionally) executed. Based on this the reconciler:
 - fetches the available chart artifact
 - performs a Helm install or upgrade action if needed
 - performs a Helm test action if enabled
-- performs a reconciliation strategy as configured (rollback, uninstall) if any Helm action failed
+- performs a reconciliation strategy (rollback, uninstall) and retries as configured if any Helm action failed
 
 The controller that runs these Helm actions relies on [source-controller](https://github.com/fluxcd/source-controller)
 for providing the Helm charts from Helm repositories or any other source that source-controller

--- a/docs/spec/v2alpha1/README.md
+++ b/docs/spec/v2alpha1/README.md
@@ -6,12 +6,17 @@ Kubernetes manifests.
 ## Specification
 
 - [`HelmRelease` CRD](helmreleases.md)
-    + [Source reference](helmreleases.md#source-reference)
+    + [Specification](helmreleases.md#specification)
+        * [Reference types](helmreleases.md#reference-types)
+        * [Status specification](helmreleases.md#status-specification)
+    + [Helm release placement](helmreleases.md#helm-release-placement)
+    + [Helm chart template](helmreleases.md#helm-chart-template)
+    + [Values overrides](helmreleases.md#values-overrides)
     + [Reconciliation](helmreleases.md#reconciliation)
-    + [`HelmRelease` dependencies](helmreleases.md#helmrelease-dependencies)
-    + [Configuring failure remediation](helmreleases.md#configuring-failure-remediation)
-    + [Enabling Helm rollback actions](helmreleases.md#enabling-helm-rollback-actions)
-    + [Enabling Helm test actions](helmreleases.md#configuring-helm-test-actions)
+        * [Disabling resource waiting](helmreleases.md#disabling-resource-waiting)
+        * [`HelmRelease` dependencies](helmreleases.md#helmrelease-dependencies)
+        * [Configuring Helm test actions](helmreleases.md#configuring-helm-test-actions)
+        * [Configuring failure remediation](helmreleases.md#configuring-failure-remediation)
     + [Status](helmreleases.md#status)
 
 ## Implementation

--- a/docs/spec/v2alpha1/helmreleases.md
+++ b/docs/spec/v2alpha1/helmreleases.md
@@ -446,16 +446,17 @@ type HelmReleaseStatus struct {
 
 ```go
 const (
-	// ReleasedCondition represents the fact that the HelmRelease has been
-	// successfully released.
+	// ReleasedCondition represents the status of the last release attempt
+	// (install/upgrade/test) against the current state.
 	ReleasedCondition string = "Released"
 
-	// TestSuccessCondition represents the fact that the tests for the HelmRelease
-	// are succeeding.
+	// TestSuccessCondition represents the status of the last test attempt against
+	// the current state.
 	TestSuccessCondition string = "TestSuccess"
 
-	// RemediatedCondition represents the fact that the HelmRelease has been
-	// successfully remediated.
+	// RemediatedCondition represents the status of the last remediation attempt
+	// (uninstall/rollback) due to a failure of the last release attempt against the
+	// current state.
 	RemediatedCondition string = "Remediated"
 )
 ```
@@ -530,7 +531,7 @@ The namespace/name in which to deploy the Helm release defaults to the namespace
 The `spec.chart.spec` values are used by the helm-controller as a template
 to create a new `HelmChart` resource with the given spec.
 
-The `HelmRelease` `spec.chart.spec.sourceRef` is a reference to an object managed by
+The `spec.chart.spec.sourceRef` is a reference to an object managed by
 [source-controller](https://github.com/fluxcd/source-controller). When the source
 [revision](https://github.com/fluxcd/source-controller/blob/master/docs/spec/v1alpha1/common.md#source-status) 
 changes, it generates a Kubernetes event that triggers a new release.
@@ -724,11 +725,11 @@ spec:
   chart:
     spec:
       chart: podinfo
-        version: '>=4.0.0 <5.0.0'
-        sourceRef:
-          kind: HelmRepository
-          name: podinfo
-        interval: 1m
+      version: '>=4.0.0 <5.0.0'
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo
+      interval: 1m
   test:
     enable: true
     ignoreFailures: true
@@ -789,21 +790,21 @@ spec:
 
 When the controller completes a reconciliation, it reports the result in the status sub-resource.
 
-The following `status.conditions` types are advertised:
+The following `status.condtions` types are advertised:
 
 * `Ready` - status of the last reconciliation attempt
 * `Released` - status of the last release attempt (install/upgrade/test) against the current state
 * `TestSuccess` - status of the last test attempt against the current state
 * `Remediated` - status of the last remediation attempt (uninstall/rollback) due to a failure of the
-  last release attempt against the current state
+   last release attempt against the current state
 
-You can wait for the helm-controller to complete a reconciliation with:
+For example, you can wait for a successful helm-controller reconciliation with:
 
 ```sh
 kubectl wait helmrelease/podinfo --for=condition=ready
 ```
 
-Each condition also includes descriptive `reason` / `message` fields
+Each of these conditions also include descriptive `reason` / `message` fields
 as to why the status is as such.
 
 ### Examples

--- a/docs/spec/v2alpha1/helmreleases.md
+++ b/docs/spec/v2alpha1/helmreleases.md
@@ -526,6 +526,10 @@ The namespace/name in which to deploy the Helm release defaults to the namespace
 `spec.releaseName`. If `spec.targetNamespace` is set, `spec.releaseName` defaults to
 `<spec.targetNamespace>-<metadata.name>`.
 
+> **Note:** that configuring the `spec.targetNamespace` only defines the namespace the release
+> is made in, the metadata for the release (also known as the "Helm storage") will always be
+> stored in the `metadata.namespace` of the `HelmRelease`.
+
 ## Helm chart template
 
 The `spec.chart.spec` values are used by the helm-controller as a template
@@ -594,13 +598,11 @@ The definition of the listed keys for items in `spec.valuesFrom` is as follows:
    transient error will still result in a reconciliation failure. Defaults to `false`
    when omitted.
 
-!!! hint "Note"
-    The `targetPath` supports the same formatting as you would supply
-    as an argument to the `helm` binary using `--set [path]=[value]`.
-    In addition to this, the referred value can contain the same
-    value formats (e.g. `{a,b,c}` for a list).
-    You can read more about the available formats and limitations in
-    the [Helm documentation](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set).
+> **Note:** that the `targetPath` supports the same formatting as you would supply as an
+> argument to the `helm` binary using `--set [path]=[value]`. In addition to this, the
+> referred value can contain the same value formats (e.g. `{a,b,c}` for a list). You can
+> read more about the available formats and limitations in the
+> [Helm documentation](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set).
 
 ## Reconciliation
 


### PR DESCRIPTION
This attempts to work towards the `extend documentation around managing Helm releases` task mentioned in https://github.com/fluxcd/toolkit/issues/238:

The thought here is to have a leveled documentation, increasing detail in each level, and avoiding too much duplication between levels:

1. https://toolkit.fluxcd.io/guides/helmreleases
2. https://toolkit.fluxcd.io/components/helm/helmreleases/
3. https://toolkit.fluxcd.io/components/helm/api/

This:

* copies some of the content about HelmRelease CRD options from 1. to 2. with the idea being to remove or reduce it from 1. and replace with a more prominent link to 2. (as a follow up in the toolkit repo).
* adds more documentation to 2.
* removes some of the copy/pasted golang documentation from 2. since it already exists in 3. The status condition types / reasons are kept (though moved under the status section) since those are not currently included in 3. This could be potentially be resolved in the future by https://github.com/ahmetb/gen-crd-api-reference-docs/issues/21
