### PR TITLE
Fix logging for next run delay

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -132,10 +132,11 @@ func (r *HelmReleaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	}
 
 	// Log reconciliation duration
-	log.Info(fmt.Sprintf("reconcilation finished in %s, next run in %s",
-		time.Now().Sub(start).String(),
-		hr.Spec.Interval.Duration.String(),
-	))
+	durationMsg := fmt.Sprintf("reconcilation finished in %s", time.Now().Sub(start).String())
+	if result.RequeueAfter > 0 {
+		durationMsg = fmt.Sprintf("%s, next run in %s", durationMsg, result.RequeueAfter.String())
+	}
+	log.Info(durationMsg)
 
 	return result, err
 }


### PR DESCRIPTION
We were logging the spec interval duration, which was incorrect:

1. On failures, which use exponential backoff
2. On dependency not ready, which uses a separately defined static interval.

This changes to log result.RequeueAfter directly when set.