### PR TITLE
Patch status sub-resource and requeue on some errors

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -251,14 +251,14 @@ func (r *HelmReleaseReconciler) reconcile(ctx context.Context, log logr.Logger, 
 	values, err := r.composeValues(ctx, hr)
 	if err != nil {
 		r.event(hr, hr.Status.LastAttemptedRevision, events.EventSeverityError, err.Error())
-		return v2.HelmReleaseNotReady(hr, v2.InitFailedReason, err.Error()), ctrl.Result{}, nil
+		return v2.HelmReleaseNotReady(hr, v2.InitFailedReason, err.Error()), ctrl.Result{Requeue: true}, nil
 	}
 
 	// Load chart from artifact
 	chart, err := r.loadHelmChart(hc)
 	if err != nil {
 		r.event(hr, hr.Status.LastAttemptedRevision, events.EventSeverityError, err.Error())
-		return v2.HelmReleaseNotReady(hr, v2.ArtifactFailedReason, err.Error()), ctrl.Result{}, nil
+		return v2.HelmReleaseNotReady(hr, v2.ArtifactFailedReason, err.Error()), ctrl.Result{Requeue: true}, nil
 	}
 
 	// Reconcile Helm release


### PR DESCRIPTION
Fixes #142 

* Requeue on chart and values composition errors to prevent a (temporary) dead lock on transient errors.
* Patch status sub-resource to resolve `the object has been modified; please apply your changes to the latest version and try again` errors and maintain better observed state.

Much of this was discovered in #127, and already applied to other controllers.