### PR TITLE
Requeue after interval on source not found errors

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -227,9 +227,9 @@ func (r *HelmReleaseReconciler) reconcile(ctx context.Context, log logr.Logger, 
 		msg := fmt.Sprintf("HelmChart '%s/%s' is not ready", hc.GetNamespace(), hc.GetName())
 		r.event(hr, hr.Status.LastAttemptedRevision, events.EventSeverityInfo, msg)
 		log.Info(msg)
-		// Do not requeue, when the artifact is created the watcher should trigger a
-		// reconciliation.
-		return v2.HelmReleaseNotReady(hr, v2.ArtifactFailedReason, msg), ctrl.Result{Requeue: false}, nil
+		// Do not requeue immediately, when the artifact is created
+		// the watcher should trigger a reconciliation.
+		return v2.HelmReleaseNotReady(hr, v2.ArtifactFailedReason, msg), ctrl.Result{RequeueAfter: hc.Spec.Interval.Duration}, nil
 	}
 
 	// Check dependencies


### PR DESCRIPTION
In case the artifact watcher doesn't receive the chart update event, we should requeue based on the specfied interval to avoid a forever stuck HelmRelease.

Fix: #153