### PR TITLE
Do not mark suspended resource as not ready

### DIFF
--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -51,8 +51,10 @@ type HelmReleaseSpec struct {
 
 	// Suspend tells the controller to suspend reconciliation for this HelmRelease,
 	// it does not apply to already started reconciliations. Defaults to false.
+	// +kubebuilder:default:=false
+	// +kubebuilder:validation:Optional
 	// +optional
-	Suspend bool `json:"suspend,omitempty"`
+	Suspend bool `json:"suspend"`
 
 	// ReleaseName used for the Helm release. Defaults to a composition of
 	// '[TargetNamespace-]Name'.
@@ -746,6 +748,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""
+// +kubebuilder:printcolumn:name="Suspended",type="boolean",JSONPath=".spec.suspend",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 
 // HelmRelease is the Schema for the helmreleases API

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -25,6 +25,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
+    - jsonPath: .spec.suspend
+      name: Suspended
+      type: boolean
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -250,6 +253,7 @@ spec:
                   when reconciling this HelmRelease.
                 type: string
               suspend:
+                default: false
                 description: Suspend tells the controller to suspend reconciliation
                   for this HelmRelease, it does not apply to already started reconciliations.
                   Defaults to false.

--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -135,6 +135,12 @@ func (r *HelmReleaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		return r.reconcileDelete(ctx, log, hr)
 	}
 
+	// Return early if the HelmRelease is suspended.
+	if hr.Spec.Suspend {
+		log.Info("Reconciliation is suspended for this object")
+		return ctrl.Result{}, nil
+	}
+
 	hr, result, err := r.reconcile(ctx, log, hr)
 
 	// Update status after reconciliation.
@@ -173,12 +179,6 @@ func (r *HelmReleaseReconciler) reconcile(ctx context.Context, log logr.Logger, 
 		}
 		// Record progressing status
 		r.recordReadiness(hr)
-	}
-
-	if hr.Spec.Suspend {
-		msg := "HelmRelease is suspended, skipping reconciliation"
-		log.Info(msg)
-		return v2.HelmReleaseNotReady(hr, meta.SuspendedReason, msg), ctrl.Result{}, nil
 	}
 
 	// Record reconciliation duration


### PR DESCRIPTION
If a resource is marked as suspended we should not perform any
reconciliation action for the resource at all.

This includes updating the status of the resource to a
`Ready==False` state, as this is not an accurate representation of
the resource's state: we have been told to no longer look at it
and with that our last observation freezes in time.

Resource deletions are the sole exception to actions (not) being
performed, as we are duty-bound to remove our finalizer from the
resource to make a deletion succeed.

To make the suspend state still visible to the user, a column has
been added to the Custom Resource Definition which prints the
`.spec.suspend` of every HelmRelease.

```
❯ kubectl get helmrelease
NAME          READY   STATUS                             SUSPENDED   AGE
podinfo       True    Release reconciliation succeeded   true        22m
podinfo-git   True    Release reconciliation succeeded   false       22m
```

Ref: https://github.com/fluxcd/flux2/issues/507