### PR TITLE
Remove default value from suspend field

### DIFF
--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -51,10 +51,8 @@ type HelmReleaseSpec struct {
 
 	// Suspend tells the controller to suspend reconciliation for this HelmRelease,
 	// it does not apply to already started reconciliations. Defaults to false.
-	// +kubebuilder:default:=false
-	// +kubebuilder:validation:Optional
 	// +optional
-	Suspend bool `json:"suspend"`
+	Suspend bool `json:"suspend,omitempty"`
 
 	// ReleaseName used for the Helm release. Defaults to a composition of
 	// '[TargetNamespace-]Name'.
@@ -748,7 +746,6 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""
-// +kubebuilder:printcolumn:name="Suspended",type="boolean",JSONPath=".spec.suspend",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 
 // HelmRelease is the Schema for the helmreleases API

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -25,9 +25,6 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
-    - jsonPath: .spec.suspend
-      name: Suspended
-      type: boolean
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -253,7 +250,6 @@ spec:
                   when reconciling this HelmRelease.
                 type: string
               suspend:
-                default: false
                 description: Suspend tells the controller to suspend reconciliation
                   for this HelmRelease, it does not apply to already started reconciliations.
                   Defaults to false.


### PR DESCRIPTION
As setting it in-cluster without commiting will otherwise result
in drift and overwrite attempts.

Given that without it the "suspended" column would show empty
fields when they are "false", this column has been removed.

Signed-off-by: Hidde Beydals <hello@hidde.co>