### PR TITLE
Support Helm's NS creation for TargetNamespace

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -94,6 +94,15 @@ jobs:
           kubectl -n default get deployment default-targetnamespace-podinfo
 
           kubectl -n helm-system delete -f config/testdata/targetnamespace
+      - name: Run install create target namespace test
+        run: |
+          kubectl -n helm-system apply -f config/testdata/install-create-target-ns
+          kubectl -n helm-system wait helmreleases/install-create-target-ns --for=condition=ready --timeout=4m
+
+          # Confirm release in "install-create-target-ns" namespace
+          kubectl -n install-create-target-ns get deployment install-create-target-ns-install-create-target-ns-podinfo
+
+          kubectl -n helm-system delete -f config/testdata/install-create-target-ns
       - name: Run install fail test
         run: |
           test_name=install-fail

--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -290,6 +290,12 @@ type Install struct {
 	// CRDs are installed if not already present.
 	// +optional
 	SkipCRDs bool `json:"skipCRDs,omitempty"`
+
+	// CreateNamespace tells the Helm install action to create the
+	// HelmReleaseSpec.TargetNamespace if it does not exist yet.
+	// On uninstall, the namespace will not be garbage collected.
+	// +optional
+	CreateNamespace bool `json:"createNamespace,omitempty"`
 }
 
 // GetTimeout returns the configured timeout for the Helm install action,

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -131,6 +131,11 @@ spec:
                 description: Install holds the configuration for Helm install actions
                   for this HelmRelease.
                 properties:
+                  createNamespace:
+                    description: CreateNamespace tells the Helm install action to
+                      create the HelmReleaseSpec.TargetNamespace if it does not exist
+                      yet. On uninstall, the namespace will not be garbage collected.
+                    type: boolean
                   disableHooks:
                     description: DisableHooks prevents hooks from running during the
                       Helm install action.

--- a/config/testdata/install-create-target-ns/helmrelease.yaml
+++ b/config/testdata/install-create-target-ns/helmrelease.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: install-create-target-ns
+spec:
+  interval: 5m
+  install:
+    createNamespace: true
+  chart:
+    spec:
+      chart: podinfo
+      version: '>=4.0.0 <5.0.0'
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo
+      interval: 1m
+  targetNamespace: install-create-target-ns

--- a/docs/api/helmrelease.md
+++ b/docs/api/helmrelease.md
@@ -1119,6 +1119,20 @@ bool
 CRDs are installed if not already present.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>createNamespace</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CreateNamespace tells the Helm install action to create the
+HelmReleaseSpec.TargetNamespace if it does not exist yet.
+On uninstall, the namespace will not be garbage collected.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>

--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -185,6 +185,12 @@ type Install struct {
 	// CRDs are installed if not already present.
 	// +optional
 	SkipCRDs bool `json:"skipCRDs,omitempty"`
+
+	// CreateNamespace tells the Helm install action to create the
+	// HelmReleaseSpec.TargetNamespace if it does not exist yet.
+	// On uninstall, the namespace will not be garbage collected.
+	// +optional
+	CreateNamespace bool `json:"createNamespace,omitempty"`
 }
 
 // InstallRemediation holds the configuration for Helm install remediation.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -60,6 +60,10 @@ func (r *Runner) Install(hr v2.HelmRelease, chart *chart.Chart, values chartutil
 	install.Replace = hr.Spec.GetInstall().Replace
 	install.SkipCRDs = hr.Spec.GetInstall().SkipCRDs
 
+	if hr.Spec.TargetNamespace != "" {
+		install.CreateNamespace = hr.Spec.GetInstall().CreateNamespace
+	}
+
 	return install.Run(chart, values.AsMap())
 }
 


### PR DESCRIPTION
This adds support for creating the target release namespace if it is not
present which can be be useful in certain scenarios.

Note that when the release is uninstalled, the namespace is not removed
and remains on the cluster, and managing your namespace _outside_ of
the HelmRelease is advised.

Fixes: #130