### PR TITLE
Share flux2 maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,8 +2,12 @@ The maintainers are generally available in Slack at
 https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages/CLAJ40HV3)
 (obtain an invitation at https://slack.cncf.io/).
 
+
+In additional to those listed below, this project shares maintainers
+from the main Flux v2 git repository, as listed in
+
+    https://github.com/fluxcd/flux2/blob/main/MAINTAINERS
+
 In alphabetical order:
 
-Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
 Sean Eagan, AT&T <sean.eagan@att.com> (github: @seaneagan, slack: seaneagan)
-Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)


### PR DESCRIPTION
See https://github.com/fluxcd/flux2/discussions/515.

@seaneagan Since you may not have seen the discussion above: this change is mainly for streamlining the maintenance of permissions and MAINTAINERS files, and not as a governance change. You can push back, if you do not wish this project to import maintainers from fluxcd/flux2.