### PR TITLE
Increase default `terminationGracePeriodSeconds` to `600`

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 600
       containers:
       - name: manager
         image: fluxcd/helm-controller


### PR DESCRIPTION
To a total of 10 minutes (600s), this allows most release process that
just have been started and make use of the default timeouts to finish.

In a future release, we will likely want to be able to stop a
reconciliation process between the reconciliation steps and continue on
the pod restart (e.g. upgrade -> terminate -> start -> continue with
test).

Helps addressing #149 