### PR TITLE
add a release deployment event when reconciling a release

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -322,6 +322,8 @@ func (r *HelmReleaseReconciler) reconcileRelease(ctx context.Context,
 		}
 	}
 
+	// Send event to mark the beginning release deploy
+	r.event(ctx, hr, revision, events.EventSeverityInfo, "Helm release deployment has started")
 	// Deploy the release.
 	var deployAction v2.DeploymentAction
 	if rel == nil {

--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -322,16 +322,16 @@ func (r *HelmReleaseReconciler) reconcileRelease(ctx context.Context,
 		}
 	}
 
-	// Send event to mark the beginning release deploy
-	r.event(ctx, hr, revision, events.EventSeverityInfo, "Helm release deployment has started")
 	// Deploy the release.
 	var deployAction v2.DeploymentAction
 	if rel == nil {
+		r.event(ctx, hr, revision, events.EventSeverityInfo, "Helm install has started")
 		deployAction = hr.Spec.GetInstall()
 		rel, err = run.Install(hr, chart, values)
 		err = r.handleHelmActionResult(ctx, &hr, revision, err, deployAction.GetDescription(),
 			v2.ReleasedCondition, v2.InstallSucceededReason, v2.InstallFailedReason)
 	} else {
+		r.event(ctx, hr, revision, events.EventSeverityInfo, "Helm upgrade has started")
 		deployAction = hr.Spec.GetUpgrade()
 		rel, err = run.Upgrade(hr, chart, values)
 		err = r.handleHelmActionResult(ctx, &hr, revision, err, deployAction.GetDescription(),


### PR DESCRIPTION
At the moment, you are not sure if the release has started and you have to wait for events showing its success or failure, or watch the status of k8s resources.
This adds an event notifying us that a release has started, we have found this to be especially useful for our slack messages in our deployment channels.