### PR TITLE
Retry with exponential backoff when fetching artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fluxcd/pkg/runtime v0.8.3
 	github.com/fluxcd/source-controller/api v0.9.0
 	github.com/go-logr/logr v0.3.0
+	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/spf13/pflag v1.0.5

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 		concurrent           int
 		requeueDependency    time.Duration
 		watchAllNamespaces   bool
+		httpRetry            int
 		clientOptions        client.Options
 		logOptions           logger.Options
 	)
@@ -76,6 +77,7 @@ func main() {
 	flag.DurationVar(&requeueDependency, "requeue-dependency", 30*time.Second, "The interval at which failing dependencies are reevaluated.")
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
+	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
 	flag.CommandLine.MarkDeprecated("log-json", "Please use --log-encoding=json instead.")
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
@@ -130,6 +132,7 @@ func main() {
 	}).SetupWithManager(mgr, controllers.HelmReleaseReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,
 		DependencyRequeueInterval: requeueDependency,
+		HTTPRetry:                 httpRetry,
 	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", v2.HelmReleaseKind)
 		os.Exit(1)


### PR DESCRIPTION
This PR implements retries with exponential backoff when fetching artifacts from source-controller. By default, the controller does 10 attempts within a 3.5 minutes window, the number of max retries can be configure using the `--http-retry` cmd arg.

This mitigates the alert spam (`i/o timeout err`) when source-controller becomes unavailable for a short period of time e.g. after an upgrade. 

Ref: https://github.com/fluxcd/flux2/discussions/661 https://github.com/fluxcd/notification-controller/issues/76