### PR TITLE
fix: log messages contain '%s'

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -540,7 +540,8 @@ func (r *HelmReleaseReconciler) composeValues(ctx context.Context, hr v2.HelmRel
 				if err := r.Get(ctx, namespacedName, resource); err != nil {
 					if apierrors.IsNotFound(err) {
 						if v.Optional {
-							(logr.FromContext(ctx)).Info("could not find optional %s '%s'", v.Kind, namespacedName)
+							(logr.FromContext(ctx)).
+								Info(fmt.Sprintf("could not find optional %s '%s'", v.Kind, namespacedName))
 							continue
 						}
 						return nil, fmt.Errorf("could not find %s '%s'", v.Kind, namespacedName)
@@ -551,7 +552,7 @@ func (r *HelmReleaseReconciler) composeValues(ctx context.Context, hr v2.HelmRel
 			}
 			if resource == nil {
 				if v.Optional {
-					(logr.FromContext(ctx)).Info("could not find optional %s '%s'", v.Kind, namespacedName)
+					(logr.FromContext(ctx)).Info(fmt.Sprintf("could not find optional %s '%s'", v.Kind, namespacedName))
 					continue
 				}
 				return nil, fmt.Errorf("could not find %s '%s'", v.Kind, namespacedName)
@@ -572,7 +573,8 @@ func (r *HelmReleaseReconciler) composeValues(ctx context.Context, hr v2.HelmRel
 				if err := r.Get(ctx, namespacedName, resource); err != nil {
 					if apierrors.IsNotFound(err) {
 						if v.Optional {
-							(logr.FromContext(ctx)).Info("could not find optional %s '%s'", v.Kind, namespacedName)
+							(logr.FromContext(ctx)).
+								Info(fmt.Sprintf("could not find optional %s '%s'", v.Kind, namespacedName))
 							continue
 						}
 						return nil, fmt.Errorf("could not find %s '%s'", v.Kind, namespacedName)
@@ -583,7 +585,7 @@ func (r *HelmReleaseReconciler) composeValues(ctx context.Context, hr v2.HelmRel
 			}
 			if resource == nil {
 				if v.Optional {
-					(logr.FromContext(ctx)).Info("could not find optional %s '%s'", v.Kind, namespacedName)
+					(logr.FromContext(ctx)).Info(fmt.Sprintf("could not find optional %s '%s'", v.Kind, namespacedName))
 					continue
 				}
 				return nil, fmt.Errorf("could not find %s '%s'", v.Kind, namespacedName)


### PR DESCRIPTION
Before:

```
{"level":"info","ts":"2021-03-03T12:45:41.305Z","logger":"controller.helmrelease","msg":"could not find optional %s '%s'","reconciler group":"helm.toolkit.fluxcd.io","reconciler kind":"HelmRelease","name":"cert-manager","namespace":"kommander","ConfigMap":{"namespace":"kommander","name":"cert-manager-overrides"}}
```

After:

```
{"level":"info","ts":"2021-03-03T13:56:46.365+0100","logger":"controller.helmrelease","msg":"could not find optional ConfigMap 'kommander/cert-manager-overrides'","reconciler group":"helm.toolkit.fluxcd.io","reconciler kind":"HelmRelease","name":"cert-manager","namespace":"kommander"}
```