### PR TITLE
Restore log buffer size to 5

### DIFF
--- a/internal/runner/log_buffer.go
+++ b/internal/runner/log_buffer.go
@@ -47,7 +47,7 @@ type LogBuffer struct {
 }
 
 func NewLogBuffer(log action.DebugLog, size int) *LogBuffer {
-	if size == 0 {
+	if size <= 0 {
 		size = defaultBufferSize
 	}
 	return &LogBuffer{

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -70,7 +70,7 @@ type Runner struct {
 // namespace configured to the provided values.
 func NewRunner(getter genericclioptions.RESTClientGetter, storageNamespace string, logger logr.Logger) (*Runner, error) {
 	runner := &Runner{
-		logBuffer: NewLogBuffer(NewDebugLog(logger).Log, 100),
+		logBuffer: NewLogBuffer(NewDebugLog(logger).Log, defaultBufferSize),
 	}
 	runner.config = new(action.Configuration)
 	if err := runner.config.Init(getter, storageNamespace, "secret", runner.logBuffer.Log); err != nil {


### PR DESCRIPTION
Changed in a6cc150aa6e4ec5c7613616f8ce194f9ae2f6e04 without a clear
reason, may be restored in the future but this depends on
[`a6cc150` (#250)](https://github.com/fluxcd/helm-controller/pull/250/commits/a6cc150aa6e4ec5c7613616f8ce194f9ae2f6e04#r617706942)