### PR TITLE
Fix HelmChartTemplateSpec Doc missing valuesFiles info

### DIFF
--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -155,9 +155,19 @@ type HelmChartTemplateSpec struct {
 	// +optional
 	Interval *metav1.Duration `json:"interval,omitempty"`
 
-	// Alternative values file to use as the default chart values, expected to be a
-	// relative path in the SourceRef. Ignored when omitted.
+	// Alternative list of values files to use as the chart values (values.yaml
+	// is not included by default), expected to be a relative path in the SourceRef.
+	// Values files are merged in the order of this list with the last file overriding
+	// the first. Ignored when omitted.
 	// +optional
+	ValuesFiles []string `json:"valuesFiles,omitempty"`
+
+	// Alternative values file to use as the default chart values, expected to
+	// be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+	// for backwards compatibility the file defined here is merged before the
+	// ValuesFiles items. Ignored when omitted.
+	// +optional
+	// +deprecated
 	ValuesFile string `json:"valuesFile,omitempty"`
 }
 


### PR DESCRIPTION
The spec docs differs from the api docs, missing the information about ValuesFiles. This also is not shown in https://fluxcd.io/docs/components/helm/helmreleases/#specification that I guess comes from this file and why I realized it was no there. I'm not sure if there is an automation for this file or not but did not find it, I saw one for the api doc one.

Signed-off-by: Filinto Duran <duranto@gmail.com>