### PR TITLE
Fix HelmRelease Values merging strategy when there's a TargetPath Array reference

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -521,7 +521,10 @@ func (r *HelmReleaseReconciler) getServiceAccountToken(ctx context.Context, hr v
 // and merges them as defined. Referenced resources are only retrieved once
 // to ensure a single version is taken into account during the merge.
 func (r *HelmReleaseReconciler) composeValues(ctx context.Context, hr v2.HelmRelease) (chartutil.Values, error) {
-	result := chartutil.Values{}
+	result := hr.GetValues()
+	if result == nil {
+		result = chartutil.Values{}
+	}
 
 	configMaps := make(map[string]*corev1.ConfigMap)
 	secrets := make(map[string]*corev1.Secret)
@@ -617,7 +620,7 @@ func (r *HelmReleaseReconciler) composeValues(ctx context.Context, hr v2.HelmRel
 			}
 		}
 	}
-	return transform.MergeMaps(result, hr.GetValues()), nil
+	return result, nil
 }
 
 // reconcileDelete deletes the v1beta1.HelmChart of the v2beta1.HelmRelease,

--- a/controllers/helmrelease_controller_test.go
+++ b/controllers/helmrelease_controller_test.go
@@ -108,6 +108,41 @@ other: values
 			},
 		},
 		{
+			name: "target path with array",
+			resources: []runtime.Object{
+				valuesSecret("values", map[string][]byte{"single": []byte("value")}),
+			},
+			references: []v2.ValuesReference{
+				{
+					Kind:       "Secret",
+					Name:       "values",
+					ValuesKey:  "single",
+					TargetPath: "merge.at.specific.path[0].url",
+				},
+			},
+			values: `
+merge:
+  at:
+    specific:
+      path:
+      - url2: value2
+`,
+			want: chartutil.Values{
+				"merge": map[string]interface{}{
+					"at": map[string]interface{}{
+						"specific": map[string]interface{}{
+							"path": []interface{}{
+								map[string]interface{}{
+									"url":  "value",
+									"url2": "value2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "values reference to non existing secret",
 			references: []v2.ValuesReference{
 				{


### PR DESCRIPTION
When using the valuesFrom.targetPath property with an array index on HelmReleases, helm-controller is not merging correctly the content of the values <> valuesFrom properties.

This PR aims to fix the issue:
https://github.com/fluxcd/helm-controller/issues/281