### PR TITLE
feat: set default observedGeneration to -1 on HelmReleases

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,8 +59,8 @@ jobs:
       - name: Run default status test
         run: |
           kubectl apply -f config/testdata/status-defaults
-          RESULT=$(kubectl get helmrelease status-defaults -o jsonpath={.status})
-          EXPECTED='{"observedGeneration":-1}'
+          RESULT=$(kubectl get helmrelease status-defaults -o go-template={{.status}})
+          EXPECTED='map[observedGeneration:-1]'
           if [ "${RESULT}" != "${EXPECTED}" ] ; then
             echo -e "${RESULT}\n\ndoes not equal\n\n${EXPECTED}"
             exit 1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -57,14 +57,14 @@ jobs:
       - name: Install CRDs
         run: make install
       - name: Run default status test
-          run: |
-            kubectl apply -f config/testdata/status-defaults
-            RESULT=$(kubectl get helmrelease status-defaults -o jsonpath={.status})
-            EXPECTED='{"observedGeneration":-1}'
-            if [ "${RESULT}" != "${EXPECTED}" ] ; then
-              echo -e "${RESULT}\n\ndoes not equal\n\n${EXPECTED}"
-              exit 1
-            fi
+        run: |
+          kubectl apply -f config/testdata/status-defaults
+          RESULT=$(kubectl get helmrelease status-defaults -o jsonpath={.status})
+          EXPECTED='{"observedGeneration":-1}'
+          if [ "${RESULT}" != "${EXPECTED}" ] ; then
+            echo -e "${RESULT}\n\ndoes not equal\n\n${EXPECTED}"
+            exit 1
+          fi
       - name: Deploy controllers
         run: |
           make dev-deploy IMG=test/helm-controller:latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -566,10 +566,10 @@ jobs:
           which kubectl
           kubectl version
           helm version
-          kubectl -n helm-system get helmrepositories -oyaml
-          kubectl -n helm-system get helmcharts -oyaml
-          kubectl -n helm-system get helmreleases -oyaml
+          kubectl -n helm-system get helmrepositories -oyaml || true
+          kubectl -n helm-system get helmcharts -oyaml || true
+          kubectl -n helm-system get helmreleases -oyaml || true
           kubectl -n helm-system get all
           helm ls -n helm-system --all
-          kubectl -n helm-system logs deploy/source-controller
-          kubectl -n helm-system logs deploy/helm-controller
+          kubectl -n helm-system logs deploy/source-controller || true
+          kubectl -n helm-system logs deploy/helm-controller || true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,6 +54,17 @@ jobs:
           KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
       - name: Load test image
         run: kind load docker-image test/helm-controller:latest
+      - name: Install CRDs
+        run: make install
+      - name: Run default status test
+          run: |
+            kubectl apply -f config/testdata/status-defaults
+            RESULT=$(kubectl get helmrelease status-defaults -o jsonpath={.status})
+            EXPECTED='{"observedGeneration":-1}'
+            if [ "${RESULT}" != "${EXPECTED}" ] ; then
+              echo -e "${RESULT}\n\ndoes not equal\n\n${EXPECTED}"
+              exit 1
+            fi
       - name: Deploy controllers
         run: |
           make dev-deploy IMG=test/helm-controller:latest

--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -882,6 +882,7 @@ type HelmRelease struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   HelmReleaseSpec   `json:"spec,omitempty"`
+	// +kubebuilder:default:={"observedGeneration":-1}
 	Status HelmReleaseStatus `json:"status,omitempty"`
 }
 

--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -881,7 +881,7 @@ type HelmRelease struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   HelmReleaseSpec   `json:"spec,omitempty"`
+	Spec HelmReleaseSpec `json:"spec,omitempty"`
 	// +kubebuilder:default:={"observedGeneration":-1}
 	Status HelmReleaseStatus `json:"status,omitempty"`
 }

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -447,6 +447,8 @@ spec:
             - interval
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: HelmReleaseStatus defines the observed state of a HelmRelease.
             properties:
               conditions:

--- a/config/testdata/status-defaults/helmrelease.yaml
+++ b/config/testdata/status-defaults/helmrelease.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: status-defaults
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: podinfo
+      version: '>=4.0.0 <5.0.0'
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo
+      interval: 1m


### PR DESCRIPTION
This resolves an issue with kustomize-controller marking a
Kustomization as healthy even when the helm-controller hasn't even
looked at the HelmRelease targeted by the Kustomization's
healthChecks, yet. Setting `observedGeneration` to -1 by default will
cause kstatus to report a status of `InProgress` instead of `Ready`.

see https://github.com/fluxcd/kustomize-controller/issues/387 for
details on the issues this is solving.

Signed-off-by: Max Jonas Werner <mail@makk.es>