### PR TITLE
Fix indentation for PostRenderers example

### DIFF
--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -1172,22 +1172,22 @@ spec:
                       operator: "Equal"
                       value: "cluster-services"
             effect: "NoSchedule"
-      # Array of inline JSON6902 patch definitions as YAML object.
-      # Note, this is a YAML object and not a string, to avoid syntax
-      # indention errors.
-      patchesJson6902:
-        - target:
-            version: v1
-            kind: Deployment
-            name: metrics-server
-          patch:
-            - op: add
-              path: /spec/template/priorityClassName
-              value: system-cluster-critical
-      images:
-        - name: docker.io/bitnami/metrics-server
-          newName: docker.io/bitnami/metrics-server
-          newTag: 0.4.1-debian-10-r54
+        # Array of inline JSON6902 patch definitions as YAML object.
+        # Note, this is a YAML object and not a string, to avoid syntax
+        # indention errors.
+        patchesJson6902:
+          - target:
+              version: v1
+              kind: Deployment
+              name: metrics-server
+            patch:
+              - op: add
+                path: /spec/template/priorityClassName
+                value: system-cluster-critical
+        images:
+          - name: docker.io/bitnami/metrics-server
+            newName: docker.io/bitnami/metrics-server
+            newTag: 0.4.1-debian-10-r54
 ```
 
 ## CRDs


### PR DESCRIPTION
Having used the indentation from the example, `images` and `patchesJson6902` are under `kustomize`. That resulted in the error:
```
validation failed: error: error validating "10f75846-394d-40a5-9fa1-73cd189b8703.yaml": error validating data: ValidationError(HelmRelease.spec.postRenderers[0]): unknown field "images" in io.fluxcd.toolkit.helm.v2beta1.HelmRelease.spec.postRenderers; if you choose to ignore these errors, turn validation off with --validate=false
```

Having shifted `images` as a field of `kustomize` seems to have worked.