### PR TITLE
Added duration in seconds as logger attribute

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -180,11 +180,13 @@ func (r *HelmReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Record ready status
 	r.recordReadiness(ctx, hr)
 
+	duration := time.Now().Sub(start)
 	// Log reconciliation duration
-	durationMsg := fmt.Sprintf("reconcilation finished in %s", time.Now().Sub(start).String())
+	durationMsg := fmt.Sprintf("reconcilation finished in %s", duration.String())
 	if result.RequeueAfter > 0 {
 		durationMsg = fmt.Sprintf("%s, next run in %s", durationMsg, result.RequeueAfter.String())
 	}
+	log.WithValues("durationSeconds", duration.Seconds())
 	log.Info(durationMsg)
 
 	return result, err


### PR DESCRIPTION
I'm trying to monitor reconciliation durations using the structured log objects, and I found it hard to extract it out of the plain message. I suggest adding another field to the log object with `durationSeconds` that can be easily turned into a metric.

I'm not quite sure how to test this new code though, seems like the logging is uncovered by the tests anyhow. 
Any advice would be appreciated!