### PR TITLE
Update the release if ReconcileStrategy changes

### DIFF
--- a/controllers/helmrelease_controller_chart.go
+++ b/controllers/helmrelease_controller_chart.go
@@ -200,6 +200,8 @@ func helmChartRequiresUpdate(hr *v2.HelmRelease, chart *sourcev1.HelmChart) bool
 		return true
 	case template.GetInterval(hr.Spec.Interval) != chart.Spec.Interval:
 		return true
+	case template.Spec.ReconcileStrategy != chart.Spec.ReconcileStrategy:
+		return true
 	case !reflect.DeepEqual(template.Spec.ValuesFiles, chart.Spec.ValuesFiles):
 		return true
 	case template.Spec.ValuesFile != chart.Spec.ValuesFile:

--- a/controllers/helmrelease_controller_chart_test.go
+++ b/controllers/helmrelease_controller_chart_test.go
@@ -421,6 +421,13 @@ func Test_helmChartRequiresUpdate(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "detects reconcile strategy change",
+			modify: func(hr *v2.HelmRelease, hc *sourcev1.HelmChart) {
+				hr.Spec.Chart.Spec.ReconcileStrategy = "Revision"
+			},
+			want: true,
+		},
+		{
 			name: "detects values files change",
 			modify: func(hr *v2.HelmRelease, hc *sourcev1.HelmChart) {
 				hr.Spec.Chart.Spec.ValuesFiles = []string{"values-prod.yaml"}


### PR DESCRIPTION
If the `ReconcileStrategy` is changed (from `ChartVersion` to `Revision` for example), we should trigger an update to the `HelmRelease`.
