### PR TITLE
Fix indentation in PostRenderer

### DIFF
--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -1171,7 +1171,7 @@ spec:
                     - key: "workload-type"
                       operator: "Equal"
                       value: "cluster-services"
-            effect: "NoSchedule"
+                      effect: "NoSchedule"
         # Array of inline JSON6902 patch definitions as YAML object.
         # Note, this is a YAML object and not a string, to avoid syntax
         # indention errors.


### PR DESCRIPTION
The indentation of this example is slightly off. This `effect` key is meant to be part of the `tolerations` array element.