### PR TITLE
Replace containerd with version that patches CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,11 +26,15 @@ require (
 	sigs.k8s.io/yaml v1.2.0
 )
 
-// freeze Helm due to OOM issues https://github.com/fluxcd/helm-controller/issues/345
+// Freeze Helm due to OOM issues https://github.com/fluxcd/helm-controller/issues/345
 replace helm.sh/helm/v3 => helm.sh/helm/v3 v3.6.3
 
-// required by https://github.com/helm/helm/blob/v3.6.3/go.mod
+// Required by https://github.com/helm/helm/blob/v3.6.3/go.mod
 replace github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d
 
-// fix CVE-2021-30465
+// Fix CVE-2021-30465
 replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc95
+
+// Fix CVE-2021-32760
+// Fix CVE-2021-41103
+replace github.com/containerd/containerd => github.com/containerd/containerd v1.4.11

--- a/go.sum
+++ b/go.sum
@@ -149,9 +149,8 @@ github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59 h1:qWj4qVYZ95vL
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
-github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
-github.com/containerd/containerd v1.4.4 h1:rtRG4N6Ct7GNssATwgpvMGfnjnwfjnu/Zs9W3Ikzq+M=
-github.com/containerd/containerd v1.4.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.4.11 h1:QCGOUN+i70jEEL/A6JVIbhy4f4fanzAzSR4kNG7SlcE=
+github.com/containerd/containerd v1.4.11/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7 h1:6ejg6Lkk8dskcM7wQ28gONkukbQkM4qpj4RnYbpFzrI=
 github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7/go.mod h1:kR3BEg7bDFaEddKm54WSmrol1fKWDU1nKYkgrcgZT7Y=


### PR DESCRIPTION
- https://github.com/advisories/GHSA-c2h3-6mxw-7mvq
- https://github.com/advisories/GHSA-c72p-9xmj-rx3w