### PR TITLE
Verify artifacts integrity

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: helm-system
 resources:
-- https://github.com/fluxcd/source-controller/releases/download/v0.16.0/source-controller.crds.yaml
-- https://github.com/fluxcd/source-controller/releases/download/v0.16.0/source-controller.deployment.yaml
+- https://github.com/fluxcd/source-controller/releases/download/v0.18.0/source-controller.crds.yaml
+- https://github.com/fluxcd/source-controller/releases/download/v0.18.0/source-controller.deployment.yaml
 - ../crd
 - ../rbac
 - ../manager

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v0.1.0
 	github.com/fluxcd/pkg/apis/meta v0.10.0
 	github.com/fluxcd/pkg/runtime v0.12.0
-	github.com/fluxcd/source-controller/api v0.16.0
+	github.com/fluxcd/source-controller/api v0.18.0
 	github.com/go-logr/logr v0.4.0
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/onsi/ginkgo v1.16.4

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/fluxcd/pkg/apis/meta v0.10.0 h1:N7wVGHC1cyPdT87hrDC7UwCwRwnZdQM46PBSL
 github.com/fluxcd/pkg/apis/meta v0.10.0/go.mod h1:CW9X9ijMTpNe7BwnokiUOrLl/h13miwVr/3abEQLbKE=
 github.com/fluxcd/pkg/runtime v0.12.0 h1:BPZZ8bBkimpqGAPXqOf3LTaw+tcw6HgbWyCuzbbsJGs=
 github.com/fluxcd/pkg/runtime v0.12.0/go.mod h1:EyaTR2TOYcjL5U//C4yH3bt2tvTgIOSXpVRbWxUn/C4=
-github.com/fluxcd/source-controller/api v0.16.0 h1:xFz+K7lLg/82uOQp+a0g04GsgoWNfyzwXAoVQy4T/oI=
-github.com/fluxcd/source-controller/api v0.16.0/go.mod h1:guUCCapjzE2kocwFreQTM/IGvtAglIJc4L97mokairo=
+github.com/fluxcd/source-controller/api v0.18.0 h1:cK1uWHCujeEm9mjPPum5gogbMXOo0C6ieVZtTTxDNkY=
+github.com/fluxcd/source-controller/api v0.18.0/go.mod h1:guUCCapjzE2kocwFreQTM/IGvtAglIJc4L97mokairo=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=


### PR DESCRIPTION
After downloading an artifact, compute its checksum and verify that it matches the original checksum as advertised by source-controller.

For backwards compatibility with source-controller v0.17.2, the checksum is computed with SHA1, on clusters with a newer source-controller we use SHA256.

Addresses https://github.com/fluxcd/source-controller/issues/468