### PR TITLE
Update Alpine to v3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY internal/ internal/
 ENV CGO_ENABLED=0
 RUN xx-go build -a -o helm-controller main.go
 
-FROM alpine:3.13
+FROM alpine:3.14
 
 # link repo to the GitHub Container Registry image
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/helm-controller"


### PR DESCRIPTION
This mitigates alerts from security scanners, when scanning helm-controller docker image:
* http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3711
* http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36159

Adding patchlevel version allows for more reproducible builds.