### PR TITLE
security: Drop capabilities, set userid and enable seccomp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,6 @@ RUN apk add --no-cache ca-certificates tini
 
 COPY --from=builder /workspace/helm-controller /usr/local/bin/
 
-RUN addgroup -S controller -g 65532 && adduser -D -u 65532 -s /sbin/nologin -S controller -G controller
-
-USER controller
+USER 65534:65534
 
 ENTRYPOINT [ "/sbin/tini", "--", "helm-controller" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apk add --no-cache ca-certificates tini
 
 COPY --from=builder /workspace/helm-controller /usr/local/bin/
 
-RUN addgroup -S controller && adduser -S controller -G controller
+RUN addgroup -S controller -g 65532 && adduser -D -u 65532 -s /sbin/nologin -S controller -G controller
 
 USER controller
 

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
         ports:
           - containerPort: 8080
             name: http-prom

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
           capabilities:
             drop: ["ALL"]
           seccompProfile:

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940 // indirect
 	github.com/yvasiyarov/gorelic v0.0.7 // indirect
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	helm.sh/helm/v3 v3.7.1
 	k8s.io/api v0.23.1
 	k8s.io/apiextensions-apiserver v0.23.1


### PR DESCRIPTION
Further restricts the `SecurityContext` that the controller runs under, by enabling the default seccomp profile, dropping all linux capabilities. 

This was set at container-level to ensure backwards compatibility with use cases in which more privileged sidecars are injected into the `source-controller` pod without setting less restrictive settings.

Note that seccomp will only be enabled if the container runtime and operational system supports it, otherwise the container will run `unconfined` (aka fail-open), which is the same behaviour as not setting the `seccompProfile` in the first place.

Relates to https://github.com/fluxcd/flux2/issues/2014
Co authored by @aryan9600

Impacts https://github.com/weaveworks/flux2-openshift/issues/10

BREAKING CHANGE: 
- The use of new seccomp API requires Kubernetes 1.19.
- The controller container is now executed under `65534:65534` (userid:groupid). This change may break deployments that hard-coded the user name 'controller' in their `PodSecurityPolicy`.