### PR TITLE
Fix inconsistent code-style raised at security audit

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -737,7 +737,10 @@ func (r *HelmReleaseReconciler) requestsForHelmChartChange(o client.Object) []re
 
 // event emits a Kubernetes event and forwards the event to notification controller if configured.
 func (r *HelmReleaseReconciler) event(ctx context.Context, hr v2.HelmRelease, revision, severity, msg string) {
-	r.EventRecorder.Event(&hr, "Normal", severity, msg)
+	if r.EventRecorder != nil {
+		r.EventRecorder.Event(&hr, "Normal", severity, msg)
+	}
+
 	objRef, err := reference.GetReference(r.Scheme, &hr)
 	if err != nil {
 		logr.FromContext(ctx).Error(err, "unable to send event")

--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -741,21 +741,23 @@ func (r *HelmReleaseReconciler) event(ctx context.Context, hr v2.HelmRelease, re
 		r.EventRecorder.Event(&hr, "Normal", severity, msg)
 	}
 
+	if r.ExternalEventRecorder == nil {
+		return
+	}
+
 	objRef, err := reference.GetReference(r.Scheme, &hr)
 	if err != nil {
 		logr.FromContext(ctx).Error(err, "unable to send event")
 		return
 	}
 
-	if r.ExternalEventRecorder != nil {
-		var meta map[string]string
-		if revision != "" {
-			meta = map[string]string{"revision": revision}
-		}
-		if err := r.ExternalEventRecorder.Eventf(*objRef, meta, severity, severity, msg); err != nil {
-			logr.FromContext(ctx).Error(err, "unable to send event")
-			return
-		}
+	var meta map[string]string
+	if revision != "" {
+		meta = map[string]string{"revision": revision}
+	}
+	if err := r.ExternalEventRecorder.Eventf(*objRef, meta, severity, severity, msg); err != nil {
+		logr.FromContext(ctx).Error(err, "unable to send event")
+		return
 	}
 }
 


### PR DESCRIPTION
Changes summary:
- Add check for nil to fix inconsistent code-style raised at the security audit.
- Short-circuit function when `ExternalEventRecorder` is nil.

Relates to https://github.com/fluxcd/pkg/issues/173