### PR TITLE
Allow setting a default service account for impersonation

### DIFF
--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -1032,6 +1032,15 @@ When the controller reconciles the `podinfo` release, it will impersonate the `w
 account. If the chart contains cluster level objects like CRDs, the reconciliation will fail since
 the account it runs under has no permissions to alter objects outside of the `webapp` namespace.
 
+### Enforce impersonation
+
+On multi-tenant clusters, platform admins can enforce impersonation with the
+`--default-service-account` flag.
+
+When the flag is set, all HelmReleases which don't have `spec.serviceAccountName` specified
+will use the service account name provided by `--default-service-account=<SA Name>`
+in the namespace of the object.
+
 ## Remote Clusters / Cluster-API
 
 If the `spec.kubeConfig` field is set, Helm actions will run against the default cluster specified
@@ -1125,6 +1134,9 @@ kubectl -n default create secret generic prod-kubeconfig \
 > or credential files from the helm-controller Pod. This matches the constraints of KubeConfigs
 > from current Cluster API providers. KubeConfigs with cmd-path in them likely won't work without
 > a custom, per-provider installation of helm-controller.
+
+When both `spec.kubeConfig` and `spec.ServiceAccountName` are specified,
+the controller will impersonate the service account on the target cluster.
 
 ## Post Renderers
 

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/fluxcd/pkg/apis/acl v0.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -318,7 +318,6 @@ github.com/fluxcd/pkg/apis/kustomize v0.3.1 h1:wmb5D9e1+Rr3/5O3235ERuj+h2VKUArVf
 github.com/fluxcd/pkg/apis/kustomize v0.3.1/go.mod h1:k2HSRd68UwgNmOYBPOd6WbX6a2MH2X/Jeh7e3s3PFPc=
 github.com/fluxcd/pkg/apis/meta v0.10.2 h1:pnDBBEvfs4HaKiVAYgz+e/AQ8dLvcgmVfSeBroZ/KKI=
 github.com/fluxcd/pkg/apis/meta v0.10.2/go.mod h1:KQ2er9xa6koy7uoPMZjIjNudB5p4tXs+w0GO6fRcy7I=
-github.com/fluxcd/pkg/runtime v0.12.3 h1:h21AZ3YG5MAP7DxFF9hfKrP+vFzys2L7CkUbPFjbP/0=
 github.com/fluxcd/pkg/runtime v0.12.3/go.mod h1:imJ2xYy/d4PbSinX2IefmZk+iS2c1P5fY0js8mCE4SM=
 github.com/fluxcd/pkg/runtime v0.12.4 h1:gA27RG/+adN2/7Qe03PB46Iwmye/MusPCpuS4zQ2fW0=
 github.com/fluxcd/pkg/runtime v0.12.4/go.mod h1:gspNvhAqodZgSmK1ZhMtvARBf/NGAlxmaZaIOHkJYsc=

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 		logOptions            logger.Options
 		aclOptions            acl.Options
 		leaderElectionOptions leaderelection.Options
+		defaultServiceAccount string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -83,6 +84,7 @@ func main() {
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
+	flag.StringVar(&defaultServiceAccount, "default-service-account", "", "Default service account used for impersonation.")
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
 	aclOptions.BindFlags(flag.CommandLine)
@@ -143,6 +145,7 @@ func main() {
 		ExternalEventRecorder: eventRecorder,
 		MetricsRecorder:       metricsRecorder,
 		NoCrossNamespaceRef:   aclOptions.NoCrossNamespaceRefs,
+		DefaultServiceAccount: defaultServiceAccount,
 	}).SetupWithManager(mgr, controllers.HelmReleaseReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,
 		DependencyRequeueInterval: requeueDependency,


### PR DESCRIPTION
Introduce the flag `--default-service-account` for allowing cluster admins to enforce impersonation across the cluster without having to use an admission controller. 

When the flag is set to a value that's not empty string, all HelmReleases which don't have `spec.serviceAccountName` specified will use the service account name provided by `--default-service-account=<SA Name>` in the namespace of the object.

**Breaking changes**: 
- When `--default-service-account=<SA name>` and/or `spec.ServiceAccountName` are specified, the controller no longer queries the API to extract and use the SA token. Instead, the controller relies on the Kubernetes impersonation feature to run the reconciliation under the `system:serviceaccount:<SA Namespace>:<SA Name>` identity. This impacts only clusters with custom made tokens and `automountServiceAccountToken` disabled. If a service account token points to a different identity (which should never be the case), then the controller will fail to reconcile with `Forbidden : User "system:serviceaccount:my-namespace:my-sa-name" cannot create resource`.
- When both `spec.kubeConfig` and `spec.ServiceAccountName` are specified, the controller will impersonate the service account on the target cluster, previously the controller ignored the service account. 

Part of: https://github.com/fluxcd/flux2/issues/2340