### PR TITLE
Allow disabling cross-namespace references

### DIFF
--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -687,6 +687,10 @@ Supported source types:
 The `HelmChart` is created in the same namespace as the `sourceRef`,
 with a name matching the `HelmRelease` `<metadata.namespace>-<metadata.name>`.
 
+> **Note** that on multi-tenant clusters,  platform admins can disable cross-namespace references
+> with the `--no-cross-namespace-refs=true` flag. When this flag is set, the helmrelease can only
+> refer to sources in the same  namespace as the helmrelease object.
+
 The `chart.spec.chart` can either contain:
 
 - The name of the chart as made available by the `HelmRepository`

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,10 @@ replace github.com/fluxcd/helm-controller/api => ./api
 
 require (
 	github.com/fluxcd/helm-controller/api v0.15.0
+	github.com/fluxcd/pkg/apis/acl v0.0.3
 	github.com/fluxcd/pkg/apis/kustomize v0.3.1
 	github.com/fluxcd/pkg/apis/meta v0.10.2
-	github.com/fluxcd/pkg/runtime v0.12.3
+	github.com/fluxcd/pkg/runtime v0.12.4
 	github.com/fluxcd/source-controller/api v0.20.1
 	github.com/go-logr/logr v1.2.2
 	github.com/hashicorp/go-retryablehttp v0.6.8

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,8 @@ github.com/fluxcd/pkg/apis/meta v0.10.2 h1:pnDBBEvfs4HaKiVAYgz+e/AQ8dLvcgmVfSeBr
 github.com/fluxcd/pkg/apis/meta v0.10.2/go.mod h1:KQ2er9xa6koy7uoPMZjIjNudB5p4tXs+w0GO6fRcy7I=
 github.com/fluxcd/pkg/runtime v0.12.3 h1:h21AZ3YG5MAP7DxFF9hfKrP+vFzys2L7CkUbPFjbP/0=
 github.com/fluxcd/pkg/runtime v0.12.3/go.mod h1:imJ2xYy/d4PbSinX2IefmZk+iS2c1P5fY0js8mCE4SM=
+github.com/fluxcd/pkg/runtime v0.12.4 h1:gA27RG/+adN2/7Qe03PB46Iwmye/MusPCpuS4zQ2fW0=
+github.com/fluxcd/pkg/runtime v0.12.4/go.mod h1:gspNvhAqodZgSmK1ZhMtvARBf/NGAlxmaZaIOHkJYsc=
 github.com/fluxcd/source-controller/api v0.20.1 h1:BfYw1gNHykiCVFNtDz3atcf3Vph+arfuveKmouI98wE=
 github.com/fluxcd/source-controller/api v0.20.1/go.mod h1:Ab2qDmAUz6ZCp8UaHYLYzxyFrC1FQqEqjxiROb/Rdiw=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	crtlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
+	"github.com/fluxcd/pkg/runtime/acl"
 	"github.com/fluxcd/pkg/runtime/client"
 	"github.com/fluxcd/pkg/runtime/events"
 	"github.com/fluxcd/pkg/runtime/leaderelection"
@@ -70,6 +71,7 @@ func main() {
 		httpRetry             int
 		clientOptions         client.Options
 		logOptions            logger.Options
+		aclOptions            acl.Options
 		leaderElectionOptions leaderelection.Options
 	)
 
@@ -83,6 +85,7 @@ func main() {
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
+	aclOptions.BindFlags(flag.CommandLine)
 	leaderElectionOptions.BindFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -139,6 +142,7 @@ func main() {
 		EventRecorder:         mgr.GetEventRecorderFor(controllerName),
 		ExternalEventRecorder: eventRecorder,
 		MetricsRecorder:       metricsRecorder,
+		NoCrossNamespaceRef:   aclOptions.NoCrossNamespaceRefs,
 	}).SetupWithManager(mgr, controllers.HelmReleaseReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,
 		DependencyRequeueInterval: requeueDependency,


### PR DESCRIPTION
Introduce the flag `--no-cross-namespace-refs` (defaults to false) for allowing cluster admins to disable cross-namespace references to sources.

When the controller is run with `--no-cross-namespace-refs=true` and `chart.spec.sourceRef` refers to a `GitRepository`, `Bucket` or `HelmRepository` in a different namespace than the `HelmRelease` object, the reconciliation will fail with the `AccessDenied` reason.

On access denied errors the controller logs and sends an event e.g.:

```
can't access 'GitRepository/my-other-namespace/my-source', cross-namespace references have been blocked
```

And the `HelmRelease` status `Ready` condition it set to:

```yaml
status:
  conditions:
  - lastTransitionTime: "2022-01-26T07:26:48Z"
    message: "can't access 'GitRepository/my-other-namespace/my-source', cross-namespace references have been blocked"
    reason: AccessDenied
    status: "False"
    type: Ready
```

Part of: https://github.com/fluxcd/flux2/issues/2337
