### PR TITLE
Add uninstall disableWait flag

### DIFF
--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -754,6 +754,11 @@ type Uninstall struct {
 	// release as deleted, but retain the release history.
 	// +optional
 	KeepHistory bool `json:"keepHistory,omitempty"`
+
+	// DisableWait disables waiting for all the resources to be deleted after
+	// a Helm uninstall is performed.
+	// +optional
+	DisableWait bool `json:"disableWait,omitempty"`
 }
 
 // GetTimeout returns the configured timeout for the Helm uninstall action, or

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -497,6 +497,10 @@ spec:
                     description: DisableHooks prevents hooks from running during the
                       Helm rollback action.
                     type: boolean
+                  disableWait:
+                    description: DisableWait disables waiting for all the resources
+                      to be deleted after a Helm uninstall is performed.
+                    type: boolean
                   keepHistory:
                     description: KeepHistory tells Helm to remove all associated resources
                       and mark the release as deleted, but retain the release history.

--- a/docs/api/helmrelease.md
+++ b/docs/api/helmrelease.md
@@ -1755,6 +1755,19 @@ bool
 release as deleted, but retain the release history.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>disableWait</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableWait disables waiting for all the resources to be deleted after
+a Helm uninstall is performed.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>

--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -433,6 +433,11 @@ type Uninstall struct {
 	// release as deleted, but retain the release history.
 	// +optional
 	KeepHistory bool `json:"keepHistory,omitempty"`
+
+	// DisableWait disables waiting for all the resources to be deleted after
+	// a Helm uninstall is performed.
+	// +optional
+	DisableWait bool `json:"disableWait,omitempty"`
 }
 
 // Kustomize Helm PostRenderer specification.
@@ -786,8 +791,8 @@ kubectl get all --all-namespaces \
 
 ### Disabling resource waiting
 
-For install, upgrade, and rollback actions resource waiting is enabled by default,
-but can be disabled by setting `spec.<action>.disableWait`.
+For install, upgrade, rollback, and uninstall actions resource waiting is
+enabled by default, but can be disabled by setting `spec.<action>.disableWait`.
 
 Waiting for jobs to complete is enabled by default, 
 but can be disabled by setting `spec.<action>.disableWaitForJobs`.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -375,6 +375,7 @@ func (r *Runner) Uninstall(hr v2.HelmRelease) error {
 	uninstall.Timeout = hr.Spec.GetUninstall().GetTimeout(hr.GetTimeout()).Duration
 	uninstall.DisableHooks = hr.Spec.GetUninstall().DisableHooks
 	uninstall.KeepHistory = hr.Spec.GetUninstall().KeepHistory
+	uninstall.Wait = !hr.Spec.GetUninstall().DisableWait
 
 	_, err := uninstall.Run(hr.GetReleaseName())
 	return wrapActionErr(r.logBuffer, err)


### PR DESCRIPTION
Add a uninstall `disableWait` property on Helm Release Uninstall API, so users can set whether Helm Controller waits for all the  resources to be deleted before finalizing the Helm Release.

This is very handy to ensure Helm Releases are fully un-installed. See [Slack Thread](https://cloud-native.slack.com/archives/CLAJ40HV3/p1644503412939859).