### PR TITLE
feat: add linux/s390x builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,6 +31,6 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/s390x
           tags: |
             ${{ env.REPOSITORY }}:nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/s390x
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Check images


### PR DESCRIPTION
Signed-off-by: skuethe <56306041+skuethe@users.noreply.github.com>

This PR adds the s390x platform to the build and release automation. As multi arch builds are setup perfectly already, the necessary changes are minimal.
A (stripped down) successful version of the github action can be seen here:
https://github.com/skuethe/helm-controller/actions/runs/1897491326

I have also just started a discussion about adding s390x to all flux components, just to not flood you with PRs without any feedback:
https://github.com/fluxcd/flux2/discussions/2475

