### PR TITLE
add fsgroup for securityContext

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         prometheus.io/port: "8080"
     spec:
       terminationGracePeriodSeconds: 600
+      securityContext:
+        # Required for AWS IAM Role bindings
+        # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
+        fsGroup: 1337
       containers:
       - name: manager
         image: fluxcd/helm-controller


### PR DESCRIPTION
Ref: https://github.com/fluxcd/flux2/issues/2537

In https://github.com/fluxcd/source-controller/issues/284#issuecomment-774703153 it seems that leaving fsGroup unset can result in this error.