### PR TITLE
Add kubeconfig flags

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -51,6 +51,7 @@ import (
 	apiacl "github.com/fluxcd/pkg/apis/acl"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/acl"
+	fluxClient "github.com/fluxcd/pkg/runtime/client"
 	"github.com/fluxcd/pkg/runtime/events"
 	"github.com/fluxcd/pkg/runtime/metrics"
 	"github.com/fluxcd/pkg/runtime/predicates"
@@ -81,6 +82,7 @@ type HelmReleaseReconciler struct {
 	MetricsRecorder       *metrics.Recorder
 	DefaultServiceAccount string
 	NoCrossNamespaceRef   bool
+	KubeConfigOpts        fluxClient.KubeConfigOptions
 }
 
 func (r *HelmReleaseReconciler) SetupWithManager(mgr ctrl.Manager, opts HelmReleaseReconcilerOptions) error {
@@ -503,7 +505,7 @@ func (r *HelmReleaseReconciler) getRESTClientGetter(ctx context.Context, hr v2.H
 		if len(kubeConfig) == 0 {
 			return nil, fmt.Errorf("KubeConfig secret '%s' does not contain a 'value' key", secretName)
 		}
-		return kube.NewMemoryRESTClientGetter(kubeConfig, hr.GetReleaseNamespace(), impersonateAccount, r.Config.QPS, r.Config.Burst), nil
+		return kube.NewMemoryRESTClientGetter(kubeConfig, hr.GetReleaseNamespace(), impersonateAccount, r.Config.QPS, r.Config.Burst, r.KubeConfigOpts), nil
 	}
 
 	if r.DefaultServiceAccount != "" || hr.Spec.ServiceAccountName != "" {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fluxcd/pkg/apis/acl v0.0.3
 	github.com/fluxcd/pkg/apis/kustomize v0.3.2
 	github.com/fluxcd/pkg/apis/meta v0.12.1
-	github.com/fluxcd/pkg/runtime v0.13.2
+	github.com/fluxcd/pkg/runtime v0.13.3
 	github.com/fluxcd/source-controller/api v0.22.3
 	github.com/go-logr/logr v1.2.3
 	github.com/hashicorp/go-retryablehttp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/fluxcd/pkg/apis/kustomize v0.3.2 h1:ULoAwOOekHf5cy6mYIwL+K6v8/cfcNVVb
 github.com/fluxcd/pkg/apis/kustomize v0.3.2/go.mod h1:p8iAH5TeqMBnnxkkpCNNDvWYfKlNRx89a6WKOo+hJHA=
 github.com/fluxcd/pkg/apis/meta v0.12.1 h1:m5PfKAqbqWBvGp9+JRj1sv+xNkGsHwUVf+3rJ8wm6SE=
 github.com/fluxcd/pkg/apis/meta v0.12.1/go.mod h1:f8YVt70/KAhqzZ7xxhjvqyzKubOYx2pAbakb/FfCEg8=
-github.com/fluxcd/pkg/runtime v0.13.2 h1:6jkQQUbp17WxHsbozlJFCvHmOS4JIB+yB20CdCd8duE=
-github.com/fluxcd/pkg/runtime v0.13.2/go.mod h1:dzWNKqFzFXeittbpFcJzR3cdC9CWlbzw+pNOgaVvF/0=
+github.com/fluxcd/pkg/runtime v0.13.3 h1:k0Xun+RoEC/F6iuAPTA6rQb+I4B4oecBx6pOcodX11A=
+github.com/fluxcd/pkg/runtime v0.13.3/go.mod h1:dzWNKqFzFXeittbpFcJzR3cdC9CWlbzw+pNOgaVvF/0=
 github.com/fluxcd/source-controller/api v0.22.3 h1:HnpSnCtIytwSGSz2qu+GJwyZRmD5UXZL5oOQapiQOtk=
 github.com/fluxcd/source-controller/api v0.22.3/go.mod h1:Vb13q9Pq+1IW/sJUZn/RSb7IU5WT86Er6uCFPCFm9L4=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/fluxcd/pkg/runtime/client"
 )
 
 func NewInClusterRESTClientGetter(cfg *rest.Config, namespace string) genericclioptions.RESTClientGetter {
@@ -49,15 +51,23 @@ type MemoryRESTClientGetter struct {
 	impersonateAccount string
 	qps                float32
 	burst              int
+	kubeConfigOpts     client.KubeConfigOptions
 }
 
-func NewMemoryRESTClientGetter(kubeConfig []byte, namespace string, impersonateAccount string, qps float32, burst int) genericclioptions.RESTClientGetter {
+func NewMemoryRESTClientGetter(
+	kubeConfig []byte,
+	namespace string,
+	impersonateAccount string,
+	qps float32,
+	burst int,
+	kubeConfigOpts client.KubeConfigOptions) genericclioptions.RESTClientGetter {
 	return &MemoryRESTClientGetter{
 		kubeConfig:         kubeConfig,
 		namespace:          namespace,
 		impersonateAccount: impersonateAccount,
 		qps:                qps,
 		burst:              burst,
+		kubeConfigOpts:     kubeConfigOpts,
 	}
 }
 
@@ -66,6 +76,7 @@ func (c *MemoryRESTClientGetter) ToRESTConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	cfg = client.KubeConfig(cfg, c.kubeConfigOpts)
 	if c.impersonateAccount != "" {
 		cfg.Impersonate = rest.ImpersonationConfig{UserName: c.impersonateAccount}
 	}

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func main() {
 		watchAllNamespaces    bool
 		httpRetry             int
 		clientOptions         client.Options
+		kubeConfigOpts        client.KubeConfigOptions
 		logOptions            logger.Options
 		aclOptions            acl.Options
 		leaderElectionOptions leaderelection.Options
@@ -89,6 +90,7 @@ func main() {
 	logOptions.BindFlags(flag.CommandLine)
 	aclOptions.BindFlags(flag.CommandLine)
 	leaderElectionOptions.BindFlags(flag.CommandLine)
+	kubeConfigOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
 	ctrl.SetLogger(logger.NewLogger(logOptions))
@@ -141,6 +143,7 @@ func main() {
 		MetricsRecorder:       metricsRecorder,
 		NoCrossNamespaceRef:   aclOptions.NoCrossNamespaceRefs,
 		DefaultServiceAccount: defaultServiceAccount,
+		KubeConfigOpts:        kubeConfigOpts,
 	}).SetupWithManager(mgr, controllers.HelmReleaseReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,
 		DependencyRequeueInterval: requeueDependency,


### PR DESCRIPTION
Two new flags were added to allow users to enable the use of user.Exec (`--insecure-kubeconfig-exec`) and InsecureTLS (`insecure-kubeconfig-tls`) in the kubeconfigs provided for remote apply.

Breaking change: both functionalities are no longer enabled by default.

Provides feature parity with `kustomize`: https://github.com/fluxcd/kustomize-controller/pull/593