### PR TITLE
Update KubeConfig documentation

### DIFF
--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -74,7 +74,12 @@ type HelmReleaseSpec struct {
 	Interval metav1.Duration `json:"interval"`
 
 	// KubeConfig for reconciling the HelmRelease on a remote cluster.
-	// When specified, KubeConfig takes precedence over ServiceAccountName.
+	// When used in combination with HelmReleaseSpec.ServiceAccountName,
+	// forces the controller to act on behalf of that Service Account at the
+	// target cluster.
+	// If the --default-service-account flag is set, its value will be used as
+	// a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+	// is empty.
 	// +optional
 	KubeConfig *KubeConfig `json:"kubeConfig,omitempty"`
 

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -237,7 +237,11 @@ spec:
                 type: string
               kubeConfig:
                 description: KubeConfig for reconciling the HelmRelease on a remote
-                  cluster. When specified, KubeConfig takes precedence over ServiceAccountName.
+                  cluster. When used in combination with HelmReleaseSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at
+                  the target cluster. If the --default-service-account flag is set,
+                  its value will be used as a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                  is empty.
                 properties:
                   secretRef:
                     description: SecretRef holds the name to a secret that contains

--- a/docs/api/helmrelease.md
+++ b/docs/api/helmrelease.md
@@ -107,7 +107,12 @@ KubeConfig
 <td>
 <em>(Optional)</em>
 <p>KubeConfig for reconciling the HelmRelease on a remote cluster.
-When specified, KubeConfig takes precedence over ServiceAccountName.</p>
+When used in combination with HelmReleaseSpec.ServiceAccountName,
+forces the controller to act on behalf of that Service Account at the
+target cluster.
+If the &ndash;default-service-account flag is set, its value will be used as
+a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+is empty.</p>
 </td>
 </tr>
 <tr>
@@ -743,7 +748,12 @@ KubeConfig
 <td>
 <em>(Optional)</em>
 <p>KubeConfig for reconciling the HelmRelease on a remote cluster.
-When specified, KubeConfig takes precedence over ServiceAccountName.</p>
+When used in combination with HelmReleaseSpec.ServiceAccountName,
+forces the controller to act on behalf of that Service Account at the
+target cluster.
+If the &ndash;default-service-account flag is set, its value will be used as
+a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+is empty.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
When the flag `--default-service-account` was added it slightly changed the behaviour of the `spec.KubeConfig` field. It now forces the impersonation to always take place, either via the contents of `spec.ServiceAccountName` or its fallback at controller level.