### PR TITLE
kube: load KubeConfig (token) from FS on every reconcile

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -493,7 +493,6 @@ func (r *HelmReleaseReconciler) buildRESTClientGetter(ctx context.Context, hr v2
 		opts = append(opts, kube.WithKubeConfig(kubeConfig, r.Config.QPS, r.Config.Burst, r.KubeConfigOpts))
 	}
 	return kube.BuildClientGetter(r.Config, hr.GetReleaseNamespace(), opts...), nil
-
 }
 
 // composeValues attempts to resolve all v2beta1.ValuesReference resources

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	k8s.io/apimachinery v0.23.6
 	k8s.io/cli-runtime v0.23.6
 	k8s.io/client-go v0.23.6
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.11.2
 	sigs.k8s.io/kustomize/api v0.11.4
 	sigs.k8s.io/yaml v1.3.0
@@ -165,7 +166,6 @@ require (
 	k8s.io/klog/v2 v2.50.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/kubectl v0.23.5 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	oras.land/oras-go v1.1.1 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.6 // indirect

--- a/internal/kube/builder.go
+++ b/internal/kube/builder.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+
+	"github.com/fluxcd/pkg/runtime/client"
+)
+
+const (
+	// DefaultKubeConfigSecretKey is the default data key ConfigFromSecret
+	// looks at when no data key is provided.
+	DefaultKubeConfigSecretKey = "value"
+	// DefaultKubeConfigSecretKeyExt is the default data key ConfigFromSecret
+	// looks at when no data key is provided, and DefaultKubeConfigSecretKey
+	// does not exist.
+	DefaultKubeConfigSecretKeyExt = DefaultKubeConfigSecretKey + ".yaml"
+)
+
+// clientGetterOptions used to BuildClientGetter.
+type clientGetterOptions struct {
+	config             *rest.Config
+	namespace          string
+	kubeConfig         []byte
+	burst              int
+	qps                float32
+	impersonateAccount string
+	kubeConfigOptions  client.KubeConfigOptions
+}
+
+// ClientGetterOption configures a genericclioptions.RESTClientGetter.
+type ClientGetterOption func(o *clientGetterOptions)
+
+// WithKubeConfig creates a MemoryRESTClientGetter configured with the provided
+// KubeConfig and other values.
+func WithKubeConfig(kubeConfig []byte, qps float32, burst int, opts client.KubeConfigOptions) func(o *clientGetterOptions) {
+	return func(o *clientGetterOptions) {
+		o.kubeConfig = kubeConfig
+		o.qps = qps
+		o.burst = burst
+		o.kubeConfigOptions = opts
+	}
+}
+
+// WithImpersonate configures the genericclioptions.RESTClientGetter to
+// impersonate the provided account name.
+func WithImpersonate(accountName string) func(o *clientGetterOptions) {
+	return func(o *clientGetterOptions) {
+		o.impersonateAccount = accountName
+	}
+}
+
+// BuildClientGetter builds a genericclioptions.RESTClientGetter based on the
+// provided options and returns the result. config and namespace are mandatory,
+// and not expected to be nil or empty.
+func BuildClientGetter(config *rest.Config, namespace string, opts ...ClientGetterOption) genericclioptions.RESTClientGetter {
+	o := &clientGetterOptions{
+		config:    config,
+		namespace: namespace,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	if len(o.kubeConfig) > 0 {
+		return NewMemoryRESTClientGetter(o.kubeConfig, namespace, o.impersonateAccount, o.qps, o.burst, o.kubeConfigOptions)
+	}
+	cfg := *config
+	SetImpersonationConfig(&cfg, namespace, o.impersonateAccount)
+	return NewInClusterRESTClientGetter(&cfg, namespace)
+}

--- a/internal/kube/builder_test.go
+++ b/internal/kube/builder_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"testing"
+
+	"github.com/fluxcd/pkg/runtime/client"
+	. "github.com/onsi/gomega"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+)
+
+func TestBuildClientGetter(t *testing.T) {
+	t.Run("with config and namespace", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &rest.Config{
+			BearerToken: "a-token",
+		}
+		namespace := "a-namespace"
+		getter := BuildClientGetter(cfg, namespace)
+		g.Expect(getter).To(BeAssignableToTypeOf(&genericclioptions.ConfigFlags{}))
+
+		flags := getter.(*genericclioptions.ConfigFlags)
+		g.Expect(flags.BearerToken).ToNot(BeNil())
+		g.Expect(*flags.BearerToken).To(Equal(cfg.BearerToken))
+		g.Expect(flags.Namespace).ToNot(BeNil())
+		g.Expect(*flags.Namespace).To(Equal(namespace))
+	})
+
+	t.Run("with kubeconfig and impersonate", func(t *testing.T) {
+		g := NewWithT(t)
+
+		namespace := "a-namespace"
+		cfg := []byte(`apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.com
+  name: example-cluster
+contexts:
+- context:
+    cluster: example-cluster
+    namespace: flux-system
+kind: Config
+preferences: {}
+users:`)
+		qps := float32(600)
+		burst := 1000
+		cfgOpts := client.KubeConfigOptions{InsecureTLS: true}
+
+		impersonate := "jane"
+
+		getter := BuildClientGetter(&rest.Config{}, namespace, WithKubeConfig(cfg, qps, burst, cfgOpts), WithImpersonate(impersonate))
+		g.Expect(getter).To(BeAssignableToTypeOf(&MemoryRESTClientGetter{}))
+
+		got := getter.(*MemoryRESTClientGetter)
+		g.Expect(got.namespace).To(Equal(namespace))
+		g.Expect(got.kubeConfig).To(Equal(cfg))
+		g.Expect(got.qps).To(Equal(qps))
+		g.Expect(got.burst).To(Equal(burst))
+		g.Expect(got.kubeConfigOpts).To(Equal(cfgOpts))
+		g.Expect(got.impersonateAccount).To(Equal(impersonate))
+	})
+
+	t.Run("with config and impersonate account", func(t *testing.T) {
+		g := NewWithT(t)
+
+		namespace := "a-namespace"
+		impersonate := "frank"
+		getter := BuildClientGetter(&rest.Config{}, namespace, WithImpersonate(impersonate))
+		g.Expect(getter).To(BeAssignableToTypeOf(&genericclioptions.ConfigFlags{}))
+
+		flags := getter.(*genericclioptions.ConfigFlags)
+		g.Expect(flags.Namespace).ToNot(BeNil())
+		g.Expect(*flags.Namespace).To(Equal(namespace))
+		g.Expect(flags.Impersonate).ToNot(BeNil())
+		g.Expect(*flags.Impersonate).To(Equal("system:serviceaccount:a-namespace:frank"))
+	})
+
+	t.Run("with config and DefaultServiceAccount", func(t *testing.T) {
+		g := NewWithT(t)
+
+		namespace := "a-namespace"
+		DefaultServiceAccountName = "frank"
+		getter := BuildClientGetter(&rest.Config{}, namespace)
+		g.Expect(getter).To(BeAssignableToTypeOf(&genericclioptions.ConfigFlags{}))
+
+		flags := getter.(*genericclioptions.ConfigFlags)
+		g.Expect(flags.Namespace).ToNot(BeNil())
+		g.Expect(*flags.Namespace).To(Equal(namespace))
+		g.Expect(flags.Impersonate).ToNot(BeNil())
+		g.Expect(*flags.Impersonate).To(Equal("system:serviceaccount:a-namespace:frank"))
+	})
+}

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -44,6 +44,9 @@ func NewInClusterRESTClientGetter(cfg *rest.Config, namespace string) genericcli
 	if sa := cfg.Impersonate.UserName; sa != "" {
 		flags.Impersonate = pointer.String(sa)
 	}
+	// In a container, we are not expected to be able to write to the
+	// home dir default. However, explicitly disabling this is better.
+	flags.CacheDir = nil
 	return flags
 }
 

--- a/internal/kube/client_test.go
+++ b/internal/kube/client_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"testing"
+
+	"github.com/fluxcd/pkg/runtime/client"
+	. "github.com/onsi/gomega"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+)
+
+var cfg = []byte(`current-context: federal-context
+apiVersion: v1
+clusters:
+- cluster:
+    api-version: v1
+    server: http://cow.org:8080
+    insecure-skip-tls-verify: true
+  name: cow-cluster
+contexts:
+- context:
+    cluster: cow-cluster
+    user: blue-user
+  name: federal-context
+kind: Config
+users:
+- name: blue-user
+  user:
+    token: foo`)
+
+func TestNewInClusterRESTClientGetter(t *testing.T) {
+	t.Run("api server config", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &rest.Config{
+			Host:        "https://example.com",
+			BearerToken: "chase-the-honey",
+			TLSClientConfig: rest.TLSClientConfig{
+				CAFile: "afile",
+			},
+		}
+
+		got := NewInClusterRESTClientGetter(cfg, "")
+		g.Expect(got).To(BeAssignableToTypeOf(&genericclioptions.ConfigFlags{}))
+
+		flags := got.(*genericclioptions.ConfigFlags)
+		fields := map[*string]*string{
+			flags.APIServer:   &cfg.Host,
+			flags.BearerToken: &cfg.BearerToken,
+			flags.CAFile:      &cfg.CAFile,
+		}
+		for f, ff := range fields {
+			g.Expect(f).ToNot(BeNil())
+			g.Expect(f).To(Equal(ff))
+			g.Expect(f).ToNot(BeIdenticalTo(ff))
+		}
+	})
+
+	t.Run("namespace", func(t *testing.T) {
+		g := NewWithT(t)
+
+		got := NewInClusterRESTClientGetter(&rest.Config{}, "a-space")
+		g.Expect(got).To(BeAssignableToTypeOf(&genericclioptions.ConfigFlags{}))
+
+		flags := got.(*genericclioptions.ConfigFlags)
+		g.Expect(flags.Namespace).ToNot(BeNil())
+		g.Expect(*flags.Namespace).To(Equal("a-space"))
+	})
+
+	t.Run("impersonation", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &rest.Config{
+			Impersonate: rest.ImpersonationConfig{
+				UserName: "system:serviceaccount:namespace:foo",
+			},
+		}
+
+		got := NewInClusterRESTClientGetter(cfg, "")
+		g.Expect(got).To(BeAssignableToTypeOf(&genericclioptions.ConfigFlags{}))
+
+		flags := got.(*genericclioptions.ConfigFlags)
+		g.Expect(flags.Impersonate).ToNot(BeNil())
+		g.Expect(*flags.Impersonate).To(Equal(cfg.Impersonate.UserName))
+	})
+}
+
+func TestMemoryRESTClientGetter_ToRESTConfig(t *testing.T) {
+	t.Run("loads REST config from KubeConfig", func(t *testing.T) {
+		g := NewWithT(t)
+		getter := NewMemoryRESTClientGetter(cfg, "", "", 0, 0, client.KubeConfigOptions{})
+
+		got, err := getter.ToRESTConfig()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got.Host).To(Equal("http://cow.org:8080"))
+		g.Expect(got.TLSClientConfig.Insecure).To(BeFalse())
+	})
+
+	t.Run("sets ImpersonationConfig", func(t *testing.T) {
+		g := NewWithT(t)
+		getter := NewMemoryRESTClientGetter(cfg, "", "someone", 0, 0, client.KubeConfigOptions{})
+
+		got, err := getter.ToRESTConfig()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got.Impersonate.UserName).To(Equal("someone"))
+	})
+
+	t.Run("uses KubeConfigOptions", func(t *testing.T) {
+		g := NewWithT(t)
+
+		agent := "a static string forever," +
+			"but static strings can have dreams and hope too"
+		getter := NewMemoryRESTClientGetter(cfg, "", "someone", 0, 0, client.KubeConfigOptions{
+			UserAgent: agent,
+		})
+
+		got, err := getter.ToRESTConfig()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got.UserAgent).To(Equal(agent))
+	})
+
+	t.Run("invalid config", func(t *testing.T) {
+		g := NewWithT(t)
+
+		getter := NewMemoryRESTClientGetter([]byte(`invalid`), "", "", 0, 0, client.KubeConfigOptions{})
+		got, err := getter.ToRESTConfig()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(got).To(BeNil())
+	})
+}
+
+func TestMemoryRESTClientGetter_ToDiscoveryClient(t *testing.T) {
+	g := NewWithT(t)
+
+	getter := NewMemoryRESTClientGetter(cfg, "", "", 400, 800, client.KubeConfigOptions{})
+	got, err := getter.ToDiscoveryClient()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got).ToNot(BeNil())
+}
+
+func TestMemoryRESTClientGetter_ToRESTMapper(t *testing.T) {
+	g := NewWithT(t)
+
+	getter := NewMemoryRESTClientGetter(cfg, "", "", 400, 800, client.KubeConfigOptions{})
+	got, err := getter.ToRESTMapper()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got).ToNot(BeNil())
+}
+
+func TestMemoryRESTClientGetter_ToRawKubeConfigLoader(t *testing.T) {
+	g := NewWithT(t)
+
+	getter := NewMemoryRESTClientGetter(cfg, "a-namespace", "impersonate", 0, 0, client.KubeConfigOptions{})
+	got := getter.ToRawKubeConfigLoader()
+	g.Expect(got).ToNot(BeNil())
+
+	cfg, err := got.ClientConfig()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg.Impersonate.UserName).To(Equal("impersonate"))
+	ns, _, err := got.Namespace()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal("a-namespace"))
+}

--- a/internal/kube/config.go
+++ b/internal/kube/config.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ConfigFromSecret returns the KubeConfig data from the provided key in the
+// given Secret, or attempts to load the data from the default `value` and
+// `value.yaml` keys. If a Secret is provided but no key with data can be
+// found, an error is returned. The secret may be nil, in which case no bytes
+// nor error are returned. Validation of the data is expected to happen while
+// decoding the bytes.
+func ConfigFromSecret(secret *corev1.Secret, key string) ([]byte, error) {
+	var kubeConfig []byte
+	if secret != nil {
+		secretName := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
+		switch {
+		case key != "":
+			kubeConfig = secret.Data[key]
+			if kubeConfig == nil {
+				return nil, fmt.Errorf("KubeConfig secret '%s' does not contain a '%s' key with data", secretName, key)
+			}
+		case secret.Data[DefaultKubeConfigSecretKey] != nil:
+			kubeConfig = secret.Data[DefaultKubeConfigSecretKey]
+		case secret.Data[DefaultKubeConfigSecretKeyExt] != nil:
+			kubeConfig = secret.Data[DefaultKubeConfigSecretKeyExt]
+		default:
+			// User did not specify a key, and the 'value' key was not defined.
+			return nil, fmt.Errorf("KubeConfig secret '%s' does not contain a '%s' or '%s' key with data", secretName, DefaultKubeConfigSecretKey, DefaultKubeConfigSecretKeyExt)
+		}
+	}
+	return kubeConfig, nil
+}

--- a/internal/kube/config_test.go
+++ b/internal/kube/config_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConfigFromSecret(t *testing.T) {
+	t.Run("with default key", func(t *testing.T) {
+		g := NewWithT(t)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "super-secret",
+				Namespace: "vault",
+			},
+			Data: map[string][]byte{
+				DefaultKubeConfigSecretKey: []byte("good"),
+				// Also confirm priority.
+				DefaultKubeConfigSecretKeyExt: []byte("bad"),
+			},
+		}
+		got, err := ConfigFromSecret(secret, "")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).To(Equal(secret.Data[DefaultKubeConfigSecretKey]))
+	})
+
+	t.Run("with default key with ext", func(t *testing.T) {
+		g := NewWithT(t)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "super-secret",
+				Namespace: "vault",
+			},
+			Data: map[string][]byte{
+				DefaultKubeConfigSecretKeyExt: []byte("good"),
+			},
+		}
+		got, err := ConfigFromSecret(secret, "")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).To(Equal(secret.Data[DefaultKubeConfigSecretKeyExt]))
+	})
+
+	t.Run("with key", func(t *testing.T) {
+		g := NewWithT(t)
+
+		key := "cola.recipe"
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "super-secret",
+				Namespace: "vault",
+			},
+			Data: map[string][]byte{
+				key: []byte("snow"),
+			},
+		}
+		got, err := ConfigFromSecret(secret, key)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).To(Equal(secret.Data[key]))
+	})
+
+	t.Run("invalid key", func(t *testing.T) {
+		g := NewWithT(t)
+
+		key := "black-hole"
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "super-secret",
+				Namespace: "vault",
+			},
+			Data: map[string][]byte{},
+		}
+		got, err := ConfigFromSecret(secret, key)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(got).To(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("secret 'vault/super-secret' does not contain a 'black-hole' key "))
+		g.Expect(got).To(Equal(secret.Data[key]))
+	})
+
+	t.Run("key without data", func(t *testing.T) {
+		g := NewWithT(t)
+
+		key := "void"
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "super-secret",
+				Namespace: "vault",
+			},
+			Data: map[string][]byte{
+				key: nil,
+			},
+		}
+		got, err := ConfigFromSecret(secret, key)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(got).To(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("does not contain a 'void' key with data"))
+	})
+
+	t.Run("no keys", func(t *testing.T) {
+		g := NewWithT(t)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "super-secret",
+				Namespace: "vault",
+			},
+			Data: map[string][]byte{},
+		}
+
+		got, err := ConfigFromSecret(secret, "")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(got).To(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("does not contain a 'value' or 'value.yaml'"))
+	})
+
+	t.Run("nil secret", func(t *testing.T) {
+		g := NewWithT(t)
+
+		got, err := ConfigFromSecret(nil, "")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).To(BeNil())
+	})
+}

--- a/internal/kube/impersonate.go
+++ b/internal/kube/impersonate.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+)
+
+// DefaultServiceAccountName can be set at runtime to enable a fallback account
+// name when no service account name is provided to SetImpersonationConfig.
+var DefaultServiceAccountName string
+
+// userNameFormat is the format of a system service account user name string.
+// It formats into `system:serviceaccount:namespace:name`.
+const userNameFormat = "system:serviceaccount:%s:%s"
+
+// SetImpersonationConfig configures the provided service account name if
+// given, or the DefaultServiceAccountName as a fallback if set. It returns
+// the configured impersonation username, or an empty string.
+func SetImpersonationConfig(cfg *rest.Config, namespace, serviceAccount string) string {
+	name := DefaultServiceAccountName
+	if serviceAccount != "" {
+		name = serviceAccount
+	}
+	if name != "" && namespace != "" {
+		username := fmt.Sprintf(userNameFormat, namespace, name)
+		cfg.Impersonate = rest.ImpersonationConfig{UserName: username}
+		return username
+	}
+	return ""
+}

--- a/internal/kube/impersonate_test.go
+++ b/internal/kube/impersonate_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+)
+
+func TestSetImpersonationConfig(t *testing.T) {
+	t.Run("DefaultServiceAccountName", func(t *testing.T) {
+		g := NewWithT(t)
+
+		DefaultServiceAccountName = "default"
+		namespace := "test"
+		expect := "system:serviceaccount:" + namespace + ":" + DefaultServiceAccountName
+
+		cfg := &rest.Config{}
+		name := SetImpersonationConfig(cfg, namespace, "")
+		g.Expect(name).To(Equal(expect))
+		g.Expect(cfg.Impersonate.UserName).ToNot(BeEmpty())
+		g.Expect(cfg.Impersonate.UserName).To(Equal(name))
+	})
+
+	t.Run("overwrite DefaultServiceAccountName", func(t *testing.T) {
+		g := NewWithT(t)
+
+		DefaultServiceAccountName = "default"
+		namespace := "test"
+		serviceAccount := "different"
+		expect := "system:serviceaccount:" + namespace + ":" + serviceAccount
+
+		cfg := &rest.Config{}
+		name := SetImpersonationConfig(cfg, namespace, serviceAccount)
+		g.Expect(name).To(Equal(expect))
+		g.Expect(cfg.Impersonate.UserName).ToNot(BeEmpty())
+		g.Expect(cfg.Impersonate.UserName).To(Equal(name))
+	})
+
+	t.Run("without namespace", func(t *testing.T) {
+		g := NewWithT(t)
+
+		serviceAccount := "account"
+
+		cfg := &rest.Config{}
+		name := SetImpersonationConfig(cfg, "", serviceAccount)
+		g.Expect(name).To(BeEmpty())
+		g.Expect(cfg.Impersonate.UserName).To(BeEmpty())
+	})
+
+	t.Run("no arguments", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &rest.Config{}
+		name := SetImpersonationConfig(cfg, "", "")
+		g.Expect(name).To(BeEmpty())
+		g.Expect(cfg.Impersonate.UserName).To(BeEmpty())
+	})
+}

--- a/main.go
+++ b/main.go
@@ -145,6 +145,7 @@ func main() {
 		EventRecorder:       eventRecorder,
 		MetricsRecorder:     metricsRecorder,
 		NoCrossNamespaceRef: aclOptions.NoCrossNamespaceRefs,
+		ClientOpts:          clientOptions,
 		KubeConfigOpts:      kubeConfigOpts,
 	}).SetupWithManager(mgr, controllers.HelmReleaseReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ import (
 
 	v2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	"github.com/fluxcd/helm-controller/controllers"
+	intkube "github.com/fluxcd/helm-controller/internal/kube"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -76,7 +77,6 @@ func main() {
 		aclOptions            acl.Options
 		leaderElectionOptions leaderelection.Options
 		rateLimiterOptions    helper.RateLimiterOptions
-		defaultServiceAccount string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -87,7 +87,7 @@ func main() {
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
-	flag.StringVar(&defaultServiceAccount, "default-service-account", "", "Default service account used for impersonation.")
+	flag.StringVar(&intkube.DefaultServiceAccountName, "default-service-account", "", "Default service account used for impersonation.")
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
 	aclOptions.BindFlags(flag.CommandLine)
@@ -139,14 +139,13 @@ func main() {
 	}
 
 	if err = (&controllers.HelmReleaseReconciler{
-		Client:                mgr.GetClient(),
-		Config:                mgr.GetConfig(),
-		Scheme:                mgr.GetScheme(),
-		EventRecorder:         eventRecorder,
-		MetricsRecorder:       metricsRecorder,
-		NoCrossNamespaceRef:   aclOptions.NoCrossNamespaceRefs,
-		DefaultServiceAccount: defaultServiceAccount,
-		KubeConfigOpts:        kubeConfigOpts,
+		Client:              mgr.GetClient(),
+		Config:              mgr.GetConfig(),
+		Scheme:              mgr.GetScheme(),
+		EventRecorder:       eventRecorder,
+		MetricsRecorder:     metricsRecorder,
+		NoCrossNamespaceRef: aclOptions.NoCrossNamespaceRefs,
+		KubeConfigOpts:      kubeConfigOpts,
 	}).SetupWithManager(mgr, controllers.HelmReleaseReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,
 		DependencyRequeueInterval: requeueDependency,


### PR DESCRIPTION
4371610e4ba2b07e1e0c5641d1145ca3fb34ee07 is a partial cherry-pick of commit ae4f499, including
changes around `kube`. This to include some of the changes around the
construction of the ConfigFlags RESTClientGetter, as an attempt to
solve token refresh issues.

As icing on the cake, 93bd5ed64fd59a9f2078e32d5b29808ca3ba1a4a always retrieves the current token from the FS which fixes #479 and https://github.com/fluxcd/flux2/issues/2074.