### PR TITLE
kube: configure proper account impersonation NS

### DIFF
--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -474,10 +474,13 @@ func (r *HelmReleaseReconciler) checkDependencies(hr v2.HelmRelease) error {
 }
 
 func (r *HelmReleaseReconciler) buildRESTClientGetter(ctx context.Context, hr v2.HelmRelease) (genericclioptions.RESTClientGetter, error) {
-	opts := []kube.ClientGetterOption{kube.WithClientOptions(r.ClientOpts)}
-	if hr.Spec.ServiceAccountName != "" {
-		opts = append(opts, kube.WithImpersonate(hr.Spec.ServiceAccountName))
+	opts := []kube.ClientGetterOption{
+		kube.WithClientOptions(r.ClientOpts),
+		// When ServiceAccountName is empty, it will fall back to the configured default.
+		// If this is not configured either, this option will result in a no-op.
+		kube.WithImpersonate(hr.Spec.ServiceAccountName, hr.GetNamespace()),
 	}
+	opts = append(opts)
 	if hr.Spec.KubeConfig != nil {
 		secretName := types.NamespacedName{
 			Namespace: hr.GetNamespace(),

--- a/internal/kube/builder.go
+++ b/internal/kube/builder.go
@@ -33,11 +33,12 @@ const (
 
 // clientGetterOptions used to BuildClientGetter.
 type clientGetterOptions struct {
-	namespace          string
-	kubeConfig         []byte
-	impersonateAccount string
-	clientOptions      client.Options
-	kubeConfigOptions  client.KubeConfigOptions
+	namespace            string
+	kubeConfig           []byte
+	impersonateAccount   string
+	impersonateNamespace string
+	clientOptions        client.Options
+	kubeConfigOptions    client.KubeConfigOptions
 }
 
 // ClientGetterOption configures a genericclioptions.RESTClientGetter.
@@ -61,10 +62,12 @@ func WithClientOptions(opts client.Options) func(o *clientGetterOptions) {
 }
 
 // WithImpersonate configures the genericclioptions.RESTClientGetter to
-// impersonate the provided account name.
-func WithImpersonate(accountName string) func(o *clientGetterOptions) {
+// impersonate with the given account name in the provided namespace.
+// If the account name is empty, DefaultServiceAccountName is assumed.
+func WithImpersonate(accountName, namespace string) func(o *clientGetterOptions) {
 	return func(o *clientGetterOptions) {
 		o.impersonateAccount = accountName
+		o.impersonateNamespace = namespace
 	}
 }
 
@@ -80,7 +83,7 @@ func BuildClientGetter(namespace string, opts ...ClientGetterOption) (genericcli
 		opt(o)
 	}
 	if len(o.kubeConfig) > 0 {
-		return NewMemoryRESTClientGetter(o.kubeConfig, namespace, o.impersonateAccount, o.clientOptions, o.kubeConfigOptions), nil
+		return NewMemoryRESTClientGetter(o.kubeConfig, namespace, o.impersonateAccount, o.impersonateNamespace, o.clientOptions, o.kubeConfigOptions), nil
 	}
-	return NewInClusterRESTClientGetter(namespace, o.impersonateAccount, &o.clientOptions)
+	return NewInClusterRESTClientGetter(namespace, o.impersonateAccount, o.impersonateNamespace, &o.clientOptions)
 }

--- a/internal/kube/builder_test.go
+++ b/internal/kube/builder_test.go
@@ -67,7 +67,7 @@ users:`)
 		cfgOpts := client.KubeConfigOptions{InsecureTLS: true}
 		impersonate := "jane"
 
-		getter, err := BuildClientGetter(namespace, WithClientOptions(clientOpts), WithKubeConfig(cfg, cfgOpts), WithImpersonate(impersonate))
+		getter, err := BuildClientGetter(namespace, WithClientOptions(clientOpts), WithKubeConfig(cfg, cfgOpts), WithImpersonate(impersonate, ""))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(getter).To(BeAssignableToTypeOf(&MemoryRESTClientGetter{}))
 
@@ -85,7 +85,8 @@ users:`)
 
 		namespace := "a-namespace"
 		impersonate := "frank"
-		getter, err := BuildClientGetter(namespace, WithImpersonate(impersonate))
+		impersonateNS := "other-namespace"
+		getter, err := BuildClientGetter(namespace, WithImpersonate(impersonate, impersonateNS))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(getter).To(BeAssignableToTypeOf(&genericclioptions.ConfigFlags{}))
 
@@ -93,16 +94,17 @@ users:`)
 		g.Expect(flags.Namespace).ToNot(BeNil())
 		g.Expect(*flags.Namespace).To(Equal(namespace))
 		g.Expect(flags.Impersonate).ToNot(BeNil())
-		g.Expect(*flags.Impersonate).To(Equal("system:serviceaccount:a-namespace:frank"))
+		g.Expect(*flags.Impersonate).To(Equal("system:serviceaccount:other-namespace:frank"))
 	})
 
-	t.Run("with DefaultServiceAccount", func(t *testing.T) {
+	t.Run("with impersonate DefaultServiceAccount", func(t *testing.T) {
 		g := NewWithT(t)
 		ctrl.GetConfig = mockGetConfig
 
 		namespace := "a-namespace"
 		DefaultServiceAccountName = "frank"
-		getter, err := BuildClientGetter(namespace)
+		impersonateNS := "other-namespace"
+		getter, err := BuildClientGetter(namespace, WithImpersonate("", impersonateNS))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(getter).To(BeAssignableToTypeOf(&genericclioptions.ConfigFlags{}))
 
@@ -110,7 +112,7 @@ users:`)
 		g.Expect(flags.Namespace).ToNot(BeNil())
 		g.Expect(*flags.Namespace).To(Equal(namespace))
 		g.Expect(flags.Impersonate).ToNot(BeNil())
-		g.Expect(*flags.Impersonate).To(Equal("system:serviceaccount:a-namespace:frank"))
+		g.Expect(*flags.Impersonate).To(Equal("system:serviceaccount:other-namespace:frank"))
 	})
 }
 


### PR DESCRIPTION
Fixing a regression introduced in #480 which would always pick the
namespace of the release. In addition, historically seen the
configuration of the impersonation username while making use of a
KubeConfig has never worked correctly, this has been adressed as well.