### PR TITLE
Disable caching of secrets and configmaps

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package features sets the feature gates that
+// helm-controller supports, and their default states.
+package features
+
+import feathelper "github.com/fluxcd/pkg/runtime/features"
+
+const (
+	// CacheSecretsAndConfigMaps configures the caching of Secrets and ConfigMaps
+	// by the controller-runtime client.
+	//
+	// When enabled, it will cache both object types, resulting in increased memory usage
+	// and cluster-wide RBAC permissions (list and watch).
+	CacheSecretsAndConfigMaps = "CacheSecretsAndConfigMaps"
+)
+
+var features = map[string]bool{
+	// CacheSecretsAndConfigMaps
+	// opt-in from v0.28
+	CacheSecretsAndConfigMaps: false,
+}
+
+// FeatureGates contains a list of all supported feature gates and
+// their default values.
+func FeatureGates() map[string]bool {
+	return features
+}
+
+// Enabled verifies whether the feature is enabled or not.
+//
+// This is only a wrapper around the Enabled func in
+// pkg/runtime/features, so callers won't need to import
+// both packages for checking whether a feature is enabled.
+func Enabled(feature string) (bool, error) {
+	return feathelper.Enabled(feature)
+}
+
+// Disable disables the specified feature. If the feature is not
+// present, it's a no-op.
+func Disable(feature string) {
+	if _, ok := features[feature]; ok {
+		features[feature] = false
+	}
+}


### PR DESCRIPTION
Fixes #512 .

By default, `controller-runtime` gives you a cache-backed client, which will perform a LIST operation on any API type that you fetch, even if you use a GET request like we do: https://github.com/fluxcd/helm-controller/blob/5a7d0f8535406d155ed7d0634b27574538febed0/controllers/helmrelease_controller.go#L556

So unless you restrict helm-controller to a specific namespace with `--watch-all-namespaces=false`, then it will attempt to populate its cache by listing all secrets in the cluster, even if it only needs to access a few in specific namespaces. That requires giving helm-controller the ability to read every secret in the cluster.

This PR allows users to avoid that restriction by disabling caching of secrets. Now users can deploy HelmReleases that use `valuesFrom` without having to grant Flux access to more secrets than necessary.