### PR TITLE
api: allow configuration of `h` unit for timeouts

### DIFF
--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -333,7 +333,7 @@ type Install struct {
 	// Jobs for hooks) during the performance of a Helm install action. Defaults to
 	// 'HelmReleaseSpec.Timeout'.
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
@@ -511,7 +511,7 @@ type Upgrade struct {
 	// Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
 	// 'HelmReleaseSpec.Timeout'.
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
@@ -694,7 +694,7 @@ type Test struct {
 	// Timeout is the time to wait for any individual Kubernetes operation during
 	// the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
@@ -721,7 +721,7 @@ type Rollback struct {
 	// Jobs for hooks) during the performance of a Helm rollback action. Defaults to
 	// 'HelmReleaseSpec.Timeout'.
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
@@ -769,7 +769,7 @@ type Uninstall struct {
 	// Jobs for hooks) during the performance of a Helm uninstall action. Defaults
 	// to 'HelmReleaseSpec.Timeout'.
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -230,7 +230,7 @@ spec:
                     description: Timeout is the time to wait for any individual Kubernetes
                       operation (like Jobs for hooks) during the performance of a
                       Helm install action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
                 type: object
               interval:
@@ -507,7 +507,7 @@ spec:
                     description: Timeout is the time to wait for any individual Kubernetes
                       operation (like Jobs for hooks) during the performance of a
                       Helm rollback action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
                 type: object
               serviceAccountName:
@@ -549,7 +549,7 @@ spec:
                     description: Timeout is the time to wait for any individual Kubernetes
                       operation during the performance of a Helm test action. Defaults
                       to 'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
                 type: object
               timeout:
@@ -578,7 +578,7 @@ spec:
                     description: Timeout is the time to wait for any individual Kubernetes
                       operation (like Jobs for hooks) during the performance of a
                       Helm uninstall action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
                 type: object
               upgrade:
@@ -665,7 +665,7 @@ spec:
                     description: Timeout is the time to wait for any individual Kubernetes
                       operation (like Jobs for hooks) during the performance of a
                       Helm upgrade action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
                 type: object
               values:


### PR DESCRIPTION
Unlike the other Flux components, there are some scenarios in which a timeout of 1h (or more) is justified to be able to Helm actions which take a long time to finish.

To support this, widen the validation added in
54aee36b3a9adaade8625965604b5d941f63dcd3 to allow the configuration of the `h` time unit again. At the cost of theoretically keeping the workers busy for a long duration of time (and thereby not processing other changes), but without causing a full denial of service.

Follow up on #533
Fixes #547 https://github.com/fluxcd/flux2/issues/3227