### PR TITLE
Allow 'h' in HelmRelease timeout field

### DIFF
--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -123,7 +123,7 @@ type HelmReleaseSpec struct {
 	// Timeout is the time to wait for any individual Kubernetes operation (like Jobs
 	// for hooks) during the performance of a Helm action. Defaults to '5m0s'.
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -584,7 +584,7 @@ spec:
                 description: Timeout is the time to wait for any individual Kubernetes
                   operation (like Jobs for hooks) during the performance of a Helm
                   action. Defaults to '5m0s'.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               uninstall:
                 description: Uninstall holds the configuration for Helm uninstall


### PR DESCRIPTION
Signed-off-by: Zhongcheng Lao <Zhongcheng.Lao@microsoft.com>

This addresses the issue that 'h' may produce a validation error when updating `HelmRelease` resource.