### PR TITLE
Allow overriding ctrl manager graceful shutdown timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,19 +64,20 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr           string
-		eventsAddr            string
-		healthAddr            string
-		concurrent            int
-		requeueDependency     time.Duration
-		watchAllNamespaces    bool
-		httpRetry             int
-		clientOptions         client.Options
-		kubeConfigOpts        client.KubeConfigOptions
-		logOptions            logger.Options
-		aclOptions            acl.Options
-		leaderElectionOptions leaderelection.Options
-		rateLimiterOptions    helper.RateLimiterOptions
+		metricsAddr             string
+		eventsAddr              string
+		healthAddr              string
+		concurrent              int
+		requeueDependency       time.Duration
+		gracefulShutdownTimeout time.Duration
+		watchAllNamespaces      bool
+		httpRetry               int
+		clientOptions           client.Options
+		kubeConfigOpts          client.KubeConfigOptions
+		logOptions              logger.Options
+		aclOptions              acl.Options
+		leaderElectionOptions   leaderelection.Options
+		rateLimiterOptions      helper.RateLimiterOptions
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -84,6 +85,7 @@ func main() {
 	flag.StringVar(&healthAddr, "health-addr", ":9440", "The address the health endpoint binds to.")
 	flag.IntVar(&concurrent, "concurrent", 4, "The number of concurrent HelmRelease reconciles.")
 	flag.DurationVar(&requeueDependency, "requeue-dependency", 30*time.Second, "The interval at which failing dependencies are reevaluated.")
+	flag.DurationVar(&gracefulShutdownTimeout, "graceful-shutdown-timeout", 0, "The duration given to the reconciler to finish before forcibly stopping.")
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
@@ -120,6 +122,7 @@ func main() {
 		LeaseDuration:                 &leaderElectionOptions.LeaseDuration,
 		RenewDeadline:                 &leaderElectionOptions.RenewDeadline,
 		RetryPeriod:                   &leaderElectionOptions.RetryPeriod,
+		GracefulShutdownTimeout:       &gracefulShutdownTimeout,
 		LeaderElectionID:              fmt.Sprintf("%s-leader-election", controllerName),
 		Namespace:                     watchNamespace,
 		Logger:                        ctrl.Log,


### PR DESCRIPTION
Overriding the default GracefulShutdownTimeout option given to the controller manager with a default of 0 (no timeout) since the helm operations are sensitive to interruption and can lead to leaving the HelmRelease in a bad state.

This will also allow users to override the option via a CLI flag `-graceful-shutdown-timeout` how much time to wait before forcibly exiting.