### PR TITLE
Set `--graceful-shutdown-timeout` default to `-1`

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 	flag.StringVar(&healthAddr, "health-addr", ":9440", "The address the health endpoint binds to.")
 	flag.IntVar(&concurrent, "concurrent", 4, "The number of concurrent HelmRelease reconciles.")
 	flag.DurationVar(&requeueDependency, "requeue-dependency", 30*time.Second, "The interval at which failing dependencies are reevaluated.")
-	flag.DurationVar(&gracefulShutdownTimeout, "graceful-shutdown-timeout", 0, "The duration given to the reconciler to finish before forcibly stopping.")
+	flag.DurationVar(&gracefulShutdownTimeout, "graceful-shutdown-timeout", -1, "The duration given to the reconciler to finish before forcibly stopping.")
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")


### PR DESCRIPTION
This is the correct default value as intended in #570.

xref: https://github.com/kubernetes-sigs/controller-runtime/blob/92234b3c49a315a1aed54dc0655c3570d02faa38/pkg/manager/manager.go#L292-L293