### PR TITLE
Align graceful-shutdown-timeout with terminationGracePeriodSeconds

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: v0.11.1
-          image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          image: kindest/node:v1.23.13
       - name: Setup Helm
         uses: fluxcd/pkg/actions/helm@main
       - name: Setup Kustomize

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 	flag.StringVar(&healthAddr, "health-addr", ":9440", "The address the health endpoint binds to.")
 	flag.IntVar(&concurrent, "concurrent", 4, "The number of concurrent HelmRelease reconciles.")
 	flag.DurationVar(&requeueDependency, "requeue-dependency", 30*time.Second, "The interval at which failing dependencies are reevaluated.")
-	flag.DurationVar(&gracefulShutdownTimeout, "graceful-shutdown-timeout", -1, "The duration given to the reconciler to finish before forcibly stopping.")
+	flag.DurationVar(&gracefulShutdownTimeout, "graceful-shutdown-timeout", 600*time.Second, "The duration given to the reconciler to finish before forcibly stopping.")
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")


### PR DESCRIPTION
Setting the default value for the graceful-shutdown-timeout flag to match the default terminationGracePeriodSeconds value we set for the controller pod container.
It seems the controller-runtime does not support passing -1 as a value to skip the timeout as documented here:
https://github.com/kubernetes-sigs/controller-runtime/blob/v0.13.1/pkg/manager/manager.go#L286

With this change, it would also make sense to update the documentation to add a new section about graceful shutdown and explain the relation between these two values and also related to how the readiness probe affects graceful shutdown.