### PR TITLE
Add post rendering step  to flatten yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/onsi/gomega v1.24.2
 	github.com/spf13/pflag v1.0.5
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.10.3
 	k8s.io/api v0.25.4
 	k8s.io/apiextensions-apiserver v0.25.4
@@ -159,7 +160,6 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.25.4 // indirect
 	k8s.io/component-base v0.25.4 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/internal/runner/post_renderer_yaml_flatten.go
+++ b/internal/runner/post_renderer_yaml_flatten.go
@@ -1,0 +1,46 @@
+package runner
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	v2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	goyaml "gopkg.in/yaml.v3"
+)
+
+func newPostRendererYamlFlatten(release *v2.HelmRelease) *postRendererYamlFlatten {
+	return &postRendererYamlFlatten{
+		name:      release.ObjectMeta.Name,
+		namespace: release.ObjectMeta.Namespace,
+	}
+}
+
+type postRendererYamlFlatten struct {
+	name      string
+	namespace string
+}
+
+func (k *postRendererYamlFlatten) Run(renderedManifests *bytes.Buffer) (modifiedManifests *bytes.Buffer, err error) {
+	decoder := goyaml.NewDecoder(renderedManifests)
+
+	var res []string
+	for {
+		var value interface{}
+		err := decoder.Decode(&value)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		valueBytes, err := goyaml.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, string(valueBytes))
+	}
+
+	concattedFlattenedYaml := strings.Join(res, "---\n")
+	return bytes.NewBufferString(concattedFlattenedYaml), nil
+}

--- a/internal/runner/post_renderer_yaml_flatten_test.go
+++ b/internal/runner/post_renderer_yaml_flatten_test.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+const aliasesAnchorsMergeKeyResourceMock = `---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-without-annotations
+---
+x-first-level-annotations:
+  annotations: &first_level_annotations
+    first_level: annotation
+    override_by_second_level: originally_set_by_first_level
+    override_by_third_level: originally_set_by_first_level
+x-second-level-annotations:
+  annotations: &second_level_annotations
+    <<: *first_level_annotations
+    second_level: annotation
+    override_by_second_level: set_by_second_level
+    override_by_third_level: set_by_second_level
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-with-annotations
+annotations:
+  <<: *second_level_annotations
+  third_level: annotation
+  override_by_third_level: set_by_third_level
+`
+
+func Test_postRendererYamlFlatten_Run(t *testing.T) {
+	tests := []struct {
+		name              string
+		renderedManifests string
+		expectManifests   string
+		expectErr         bool
+	}{
+		{
+			name:              "flattened-yaml",
+			renderedManifests: aliasesAnchorsMergeKeyResourceMock,
+			expectManifests: `apiVersion: v1
+kind: Service
+metadata:
+    name: service-without-annotations
+---
+annotations:
+    first_level: annotation
+    override_by_second_level: set_by_second_level
+    override_by_third_level: set_by_third_level
+    second_level: annotation
+    third_level: annotation
+apiVersion: v1
+kind: Service
+metadata:
+    name: service-with-annotations
+x-first-level-annotations:
+    annotations:
+        first_level: annotation
+        override_by_second_level: originally_set_by_first_level
+        override_by_third_level: originally_set_by_first_level
+x-second-level-annotations:
+    annotations:
+        first_level: annotation
+        override_by_second_level: set_by_second_level
+        override_by_third_level: set_by_second_level
+        second_level: annotation
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &postRendererYamlFlatten{
+				name:      "name",
+				namespace: "namespace",
+			}
+			gotModifiedManifests, err := k.Run(bytes.NewBufferString(tt.renderedManifests))
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Run() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if !reflect.DeepEqual(gotModifiedManifests, bytes.NewBufferString(tt.expectManifests)) {
+				t.Errorf("Run() gotModifiedManifests = \"%v\", want \"%v\"", gotModifiedManifests, tt.expectManifests)
+			}
+		})
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -83,6 +83,7 @@ func NewRunner(getter genericclioptions.RESTClientGetter, storageNamespace strin
 // a single combined post renderer.
 func postRenderers(hr v2.HelmRelease) (postrender.PostRenderer, error) {
 	var combinedRenderer = newCombinedPostRenderer()
+	combinedRenderer.addRenderer(newPostRendererYamlFlatten(&hr))
 	for _, r := range hr.Spec.PostRenderers {
 		if r.Kustomize != nil {
 			combinedRenderer.addRenderer(newPostRendererKustomize(r.Kustomize))


### PR DESCRIPTION
The kustomize yaml parser used in later post rendering steps does not handle YAML anchors, aliases and merge keys well.

In order to workaround this, this change introduces a post renderer that executes first that will flatten out all the yaml using golangs yaml parser.