### PR TITLE
helm: enable DNS with AllowDNSLookups feature gate

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -32,6 +32,12 @@ const (
 	// the desired state as described in the manifest of the Helm release
 	// storage object.
 	DetectDrift = "DetectDrift"
+
+	// AllowDNSLookups allows the controller to perform DNS lookups when rendering Helm
+	// templates. This is disabled by default, as it can be a security risk.
+	//
+	// Ref: https://github.com/helm/helm/security/advisories/GHSA-pwcw-6f5g-gxf8
+	AllowDNSLookups = "AllowDNSLookups"
 )
 
 var features = map[string]bool{
@@ -41,6 +47,9 @@ var features = map[string]bool{
 	// DetectClusterStateDrift
 	// opt-in from v0.31
 	DetectDrift: false,
+	// AllowDNSLookups
+	// opt-in from v0.31
+	AllowDNSLookups: false,
 }
 
 // FeatureGates contains a list of all supported feature gates and

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	v2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	"github.com/fluxcd/helm-controller/internal/features"
 )
 
 var accessor = meta.NewAccessor()
@@ -120,6 +121,11 @@ func (r *Runner) Install(ctx context.Context, hr v2.HelmRelease, chart *chart.Ch
 		install.CreateNamespace = hr.Spec.GetInstall().CreateNamespace
 	}
 
+	// If user opted-in to allow DNS lookups, enable it.
+	if allowDNS, _ := features.Enabled(features.AllowDNSLookups); allowDNS {
+		install.EnableDNS = allowDNS
+	}
+
 	renderer, err := postRenderers(hr)
 	if err != nil {
 		return nil, wrapActionErr(r.logBuffer, err)
@@ -164,6 +170,11 @@ func (r *Runner) Upgrade(ctx context.Context, hr v2.HelmRelease, chart *chart.Ch
 	upgrade.Force = hr.Spec.GetUpgrade().Force
 	upgrade.CleanupOnFail = hr.Spec.GetUpgrade().CleanupOnFail
 	upgrade.Devel = true
+
+	// If user opted-in to allow DNS lookups, enable it.
+	if allowDNS, _ := features.Enabled(features.AllowDNSLookups); allowDNS {
+		upgrade.EnableDNS = allowDNS
+	}
 
 	renderer, err := postRenderers(hr)
 	if err != nil {


### PR DESCRIPTION
This allows install and upgrade actions to use DNS lookups while rendering Helm templates after it got disabled in Helm due to possible security risks.

It is enabled (globally) on the controller by configuring `--feature-gates=AllowDNSLookups=true`.

Fixes: #618