### PR TITLE
check if service account exists before uninstalling release

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -536,6 +536,18 @@ jobs:
             fi
           done
           echo ' done'
+      - name: Run delete-ns tests
+        run: |
+          kubectl apply -f config/testdata/delete-ns
+          kubectl -n delete-ns wait helmreleases/podinfo --for=condition=ready --timeout=2m
+          kubectl delete ns delete-ns 1>/dev/null 2>&1 &
+          echo -n ">> Waiting for namespace to be deleted"
+          if kubectl wait --for=delete namespace delete-ns --timeout=2m; then
+            echo 'Namespace deleted successfully'
+          else
+            echo 'Timed out waiting for namespace to be deleted'
+            exit 1
+          fi
       - name: Run post-renderer-kustomize test
         run: |
           kubectl -n helm-system apply -f config/testdata/post-renderer-kustomize

--- a/config/testdata/delete-ns/test.yaml
+++ b/config/testdata/delete-ns/test.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: delete-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gotk-reconciler
+  namespace: delete-ns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gotk-reconciler
+  namespace: delete-ns
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gotk-reconciler
+  namespace: delete-ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gotk-reconciler
+subjects:
+  - kind: ServiceAccount
+    name: gotk-reconciler
+    namespace: delete-ns
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: podinfo
+  namespace: delete-ns
+spec:
+  interval: 1m
+  url: https://stefanprodan.github.io/podinfo
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: delete-ns
+spec:
+  serviceAccountName: gotk-reconciler
+  interval: 5m
+  chart:
+    spec:
+      chart: podinfo
+      version: 5.0.3
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo


### PR DESCRIPTION
Check if the service account to be impersonated actually exists
and proceed with uninstalling the Helm release only if it does.
Otherwise, skip uninstalling the release and carry on with finalization.
Add an e2e test to check if deleting a namespace with the RBAC and
HelmRelease succeeds with the namespace being fully deleted.
