### PR TITLE
runner: configure Helm action cfg log levels

### DIFF
--- a/internal/runner/log_buffer.go
+++ b/internal/runner/log_buffer.go
@@ -28,16 +28,10 @@ import (
 
 const defaultBufferSize = 5
 
-type DebugLog struct {
-	log logr.Logger
-}
-
-func NewDebugLog(log logr.Logger) *DebugLog {
-	return &DebugLog{log: log}
-}
-
-func (l *DebugLog) Log(format string, v ...interface{}) {
-	l.log.Info(fmt.Sprintf(format, v...))
+func NewDebugLog(log logr.Logger) action.DebugLog {
+	return func(format string, v ...interface{}) {
+		log.Info(fmt.Sprintf(format, v...))
+	}
 }
 
 type LogBuffer struct {

--- a/internal/runner/log_buffer.go
+++ b/internal/runner/log_buffer.go
@@ -37,7 +37,7 @@ func NewDebugLog(log logr.Logger) *DebugLog {
 }
 
 func (l *DebugLog) Log(format string, v ...interface{}) {
-	l.log.V(1).Info(fmt.Sprintf(format, v...))
+	l.log.Info(fmt.Sprintf(format, v...))
 }
 
 type LogBuffer struct {

--- a/internal/runner/log_buffer_test.go
+++ b/internal/runner/log_buffer_test.go
@@ -54,7 +54,7 @@ func TestLogBuffer_Log(t *testing.T) {
 
 func TestLogBuffer_Reset(t *testing.T) {
 	bufferSize := 10
-	l := NewLogBuffer(NewDebugLog(logr.Discard()).Log, bufferSize)
+	l := NewLogBuffer(NewDebugLog(logr.Discard()), bufferSize)
 
 	if got := l.buffer.Len(); got != bufferSize {
 		t.Errorf("Len() = %v, want %v", got, bufferSize)
@@ -91,7 +91,7 @@ func TestLogBuffer_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := NewLogBuffer(NewDebugLog(logr.Discard()).Log, tt.size)
+			l := NewLogBuffer(NewDebugLog(logr.Discard()), tt.size)
 			for _, v := range tt.fill {
 				l.Log("%s", v)
 			}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -76,10 +76,10 @@ type Runner struct {
 // namespace configured to the provided values.
 func NewRunner(getter genericclioptions.RESTClientGetter, storageNamespace string, logger logr.Logger) (*Runner, error) {
 	runner := &Runner{
-		logBuffer: NewLogBuffer(NewDebugLog(logger.V(runtimelogger.DebugLevel)).Log, defaultBufferSize),
+		logBuffer: NewLogBuffer(NewDebugLog(logger.V(runtimelogger.DebugLevel)), defaultBufferSize),
 	}
 	cfg := new(action.Configuration)
-	if err := cfg.Init(getter, storageNamespace, "secret", NewDebugLog(logger.V(runtimelogger.TraceLevel)).Log); err != nil {
+	if err := cfg.Init(getter, storageNamespace, "secret", NewDebugLog(logger.V(runtimelogger.TraceLevel))); err != nil {
 		return nil, err
 	}
 	// Override the logger used by the Helm actions with the log buffer.


### PR DESCRIPTION
This reduces the amount of log lines pushed to `debug` by configuring the kube client and storage loggers to only log to `trace`.

In addition, the log buffer used in events will now just contain the most relevant information about a failure as reported by the Helm action itself, and not the in-depth information from the underlying client and/or storage.