### PR TITLE
Use `logger.SetLogger` to also configure `klog`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fluxcd/pkg/apis/event v0.4.1
 	github.com/fluxcd/pkg/apis/kustomize v0.8.1
 	github.com/fluxcd/pkg/apis/meta v0.19.1
-	github.com/fluxcd/pkg/runtime v0.30.0
+	github.com/fluxcd/pkg/runtime v0.31.0
 	github.com/fluxcd/pkg/ssa v0.24.1
 	github.com/fluxcd/source-controller/api v0.35.2
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/fluxcd/pkg/apis/kustomize v0.8.1 h1:uRH9xVDJfSBGIiL6PIhkguHvf2Nme6uTW
 github.com/fluxcd/pkg/apis/kustomize v0.8.1/go.mod h1:TBem+2mHp6Ib7XD1fmzDkoUnBzx07wSzIYo6BVx3XAc=
 github.com/fluxcd/pkg/apis/meta v0.19.1 h1:fCI5CnTXpAqr67UlaI9q0H+OztMKB5kDTr6xV6vlAo0=
 github.com/fluxcd/pkg/apis/meta v0.19.1/go.mod h1:ZPPMYrPnWwPQYNEGM/Uc0N4SurUPS3xNI3IIpCQEfuM=
-github.com/fluxcd/pkg/runtime v0.30.0 h1:mAC6uO0q/K3lQ3QnBCBWyleplrYlppQ6Dco5kXH1L40=
-github.com/fluxcd/pkg/runtime v0.30.0/go.mod h1:wzJVtLLf34v1wPhSoB+z8qkwS/pZqUArjSoCcekXc30=
+github.com/fluxcd/pkg/runtime v0.31.0 h1:addyXaANHl/A68bEjCbiR4HzcFKgfXv1eaG7B7ZHxOo=
+github.com/fluxcd/pkg/runtime v0.31.0/go.mod h1:toGOOubMo4ZC1aWhB8C3drdTglr1/A1dETeNwjiIv0g=
 github.com/fluxcd/pkg/ssa v0.24.1 h1:0dn5FqyYdGa+VuDp5EJrkLbPq5xhhSAAkMgGUeMpOM0=
 github.com/fluxcd/pkg/ssa v0.24.1/go.mod h1:nEOUOwGotBlNZkTkO6GHPlI0U0BmHTavFd1Jk+TzsGw=
 github.com/fluxcd/source-controller/api v0.35.2 h1:1xTB0hIR8pmE8JJUQd41dHPbPx4a7EnH5iPY6bg83Oc=

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 
 	flag.Parse()
 
-	ctrl.SetLogger(logger.NewLogger(logOptions))
+	logger.SetLogger(logger.NewLogger(logOptions))
 
 	err := featureGates.WithLogger(setupLog).
 		SupportedFeatures(features.FeatureGates())


### PR DESCRIPTION
This uses the newly introduced helper from runtime, which also configures the logger for `klog`.

Resulting in all logs now being properly formatted, even when logged by internal Kubernetes elements like the leader election or a dynamic client.