### PR TITLE
Update Alpine to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY internal/ internal/
 ENV CGO_ENABLED=0
 RUN xx-go build -trimpath -a -o helm-controller main.go
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 # link repo to the GitHub Container Registry image
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/helm-controller"


### PR DESCRIPTION
This change would be nice to get in because MUSL finally implemented TCP fallback in their DNS resolver.

alpinelinux.org/posts/Alpine-3.18.0-released.html