### PR TITLE
Fix HelmRelease reconciliation loop

### DIFF
--- a/internal/controller/helmrelease_controller.go
+++ b/internal/controller/helmrelease_controller.go
@@ -483,6 +483,10 @@ func (r *HelmReleaseReconciler) reconcileRelease(ctx context.Context,
 	}
 
 	hr.Status.LastReleaseRevision = util.ReleaseRevision(rel)
+	if updateStatusErr := r.patchStatus(ctx, &hr); updateStatusErr != nil {
+		log.Error(updateStatusErr, "unable to update status after state update")
+		return hr, updateStatusErr
+	}
 
 	if err != nil {
 		reason := v2.ReconciliationFailedReason


### PR DESCRIPTION
Likely after the upgrade to controller-runtime v0.15.0 a regression surfaced for long-running reconciliations of HelmRelease resources (e.g. for charts having pre-upgrade hooks taking a few minutes to complete). This regression would cause the controller to immediately re-run the upgrade after a successful upgrade, thus entering an almost-endless loop.

Apparently, the only fix to this issue is to ensure `.Status.LastReleaseRevision` is updated as soon as possible in the reconiliation cycle rather than wait for the update at the end of the cycle.