### PR TITLE
Align docs structure with other controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ manifests: controller-gen
 
 # Generate API reference documentation
 api-docs: gen-crd-api-reference-docs
-	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir=./api/v2beta1 -config=./hack/api-docs/config.json -template-dir=./hack/api-docs/template -out-file=./docs/api/helmrelease.md
+	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir=./api/v2beta1 -config=./hack/api-docs/config.json -template-dir=./hack/api-docs/template -out-file=./docs/api/v2beta1/helm.md
 
 # Run go mod tidy
 tidy:

--- a/docs/api/v2beta1/helm.md
+++ b/docs/api/v2beta1/helm.md
@@ -1,4 +1,4 @@
-<h1>HelmRelease API reference</h1>
+<h1>Helm API reference v2beta1</h1>
 <p>Packages:</p>
 <ul class="simple">
 <li>

--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -1,5 +1,7 @@
 # Helm Releases
 
+<!-- menuweight:20 -->
+
 The `HelmRelease` API defines a resource for automated controller driven Helm releases.
 
 ## Specification

--- a/hack/api-docs/template/pkg.tpl
+++ b/hack/api-docs/template/pkg.tpl
@@ -1,5 +1,10 @@
 {{ define "packages" }}
-    <h1>HelmRelease API reference</h1>
+    <h1>Helm API reference
+        {{- with (index .packages 0) -}}
+            {{ with (index .GoPackages 0 ) -}}
+                {{ printf " %s" .Name -}}
+            {{ end -}}
+        {{ end }}</h1>
 
     {{ with .packages}}
         <p>Packages:</p>


### PR DESCRIPTION
In some controller we already support multiple API versions at the same time. In order to streamline the docs structure, the necessary changes to do the same in this repo are applied here as well.

refs fluxcd/website#1577
