### PR TITLE
Check source for nil artifact before loading chart

### DIFF
--- a/internal/controller/helmrelease_controller_chart.go
+++ b/internal/controller/helmrelease_controller_chart.go
@@ -111,6 +111,11 @@ func (r *HelmReleaseReconciler) getHelmChart(ctx context.Context, hr *v2.HelmRel
 // loads it into a chart.Chart, and removes the downloaded artifact.
 // It returns the loaded chart.Chart on success, or an error.
 func (r *HelmReleaseReconciler) loadHelmChart(source *sourcev1b2.HelmChart) (*chart.Chart, error) {
+	artifact := source.GetArtifact()
+	if artifact == nil {
+		return nil, fmt.Errorf("cannot load chart: HelmChart '%s/%s' has no artifact", source.GetNamespace(), source.GetName())
+	}
+
 	f, err := os.CreateTemp("", fmt.Sprintf("%s-%s-*.tgz", source.GetNamespace(), source.GetName()))
 	if err != nil {
 		return nil, err
@@ -118,7 +123,7 @@ func (r *HelmReleaseReconciler) loadHelmChart(source *sourcev1b2.HelmChart) (*ch
 	defer f.Close()
 	defer os.Remove(f.Name())
 
-	artifactURL := source.GetArtifact().URL
+	artifactURL := artifact.URL
 	if hostname := os.Getenv("SOURCE_CONTROLLER_LOCALHOST"); hostname != "" {
 		u, err := url.Parse(artifactURL)
 		if err != nil {


### PR DESCRIPTION
This pull request adds a check for nil artifact when determining if the source chart is ready.

A recovered nil panic was reported on Slack.
https://cloud-native.slack.com/archives/CLAJ40HV3/p1694379977158039?thread_ts=1694280268.559579&cid=CLAJ40HV3

> {"level":"error","ts":"2023-09-08T18:12:10.583Z","logger":"runtime","msg":"Observed a panic: \"invalid memory address or nil pointer dereference\" (runtime error: invalid memory address or nil pointer dereference)\ngoroutine 118 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x1ddc280?, 0x342b2c0})\n\tk8s.io/apimachinery@v0.27.4/pkg/util/runtime/runtime.go:75 +0x99\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()\n\tsigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:107 +0xc5\npanic({0x1ddc280, 0x342b2c0})\n\truntime/panic.go:884 +0x213\ngithub.com/fluxcd/helm-controller/internal/controller.(*HelmReleaseReconciler).loadHelmChart(0xc000382000, 0xc00097a000)\n\tgithub.com/fluxcd/helm-controller/internal/controller/helmrelease_controller_chart.go:121 +0x1d7\ngithub.com/fluxcd/helm-controller/internal/controller.(*HelmReleaseReconciler).reconcile(_, {_, _}, {{{0x1be17b9, 0xb}, {0xc000058120, 0x1e}}, {{0xc00055d9b0, 0xf}, {0x0, ...}, ...}, ...})\n\tgithub.com/fluxcd/helm-controller/internal/controller/helmrelease_controller.go:267 +0x7b6\ngithub.com/fluxcd/helm-controller/internal/controller.(*HelmReleaseReconciler).Reconcile(0xc000382000, {0x23c24f0, 0xc00073c240}, {{{0xc00055d9a8?, 0x8?}, {0xc00055d9b0?, 0xf?}}})\n\tgithub.com/fluxcd/helm-controller/internal/controller/helmrelease_controller.go:183 +0x550\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x23c24f0?, {0x23c24f0?, 0xc00073c240?}, {{{0xc00055d9a8?, 0x1ce3c60?}, {0xc00055d9b0?, 0x23ad4a8?}}})\n\tsigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:118 +0xc8\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000504140, {0x23c2448, 0xc0003e1130}, {0x1eabd40?, 0xc0008624a0?})\n\tsigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:314 +0x377\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000504140, {0x23c2448, 0xc0003e1130})\n\tsigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:265 +0x1d9\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()\n\tsigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:226 +0x85\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2\n\tsigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:222 +0x587\n"

