### PR TITLE
Correct cluster drift using patches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,13 +15,14 @@ replace (
 )
 
 require (
+	github.com/fluxcd/cli-utils v0.36.0-flux.1
 	github.com/fluxcd/helm-controller/api v0.36.2
 	github.com/fluxcd/pkg/apis/acl v0.1.0
 	github.com/fluxcd/pkg/apis/event v0.6.0
 	github.com/fluxcd/pkg/apis/kustomize v1.2.0
 	github.com/fluxcd/pkg/apis/meta v1.2.0
 	github.com/fluxcd/pkg/runtime v0.43.0
-	github.com/fluxcd/pkg/ssa v0.34.0
+	github.com/fluxcd/pkg/ssa v0.35.0
 	github.com/fluxcd/pkg/testserver v0.5.0
 	github.com/fluxcd/source-controller/api v1.1.2
 	github.com/go-logr/logr v1.3.0
@@ -77,7 +78,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.7.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/fluxcd/cli-utils v0.36.0-flux.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/fluxcd/pkg/apis/meta v1.2.0 h1:O766PzGAdMdQKybSflGL8oV0+GgCNIkdsxfalR
 github.com/fluxcd/pkg/apis/meta v1.2.0/go.mod h1:fU/Az9AoVyIxC0oI4ihG0NVMNnvrcCzdEym3wxjIQsc=
 github.com/fluxcd/pkg/runtime v0.43.0 h1:dU4cWct5VTpddGzJUU80zxNl80jbbVEN5Y5rbt4YUnw=
 github.com/fluxcd/pkg/runtime v0.43.0/go.mod h1:RuqJ9VEXELjzgurK2+UXBBgVN1vS0hZ7CYVG2xBAEVM=
-github.com/fluxcd/pkg/ssa v0.34.0 h1:hpMo0D7G3faieRYH39e9YD8Jl+aC2hTgUep8ojG5+LE=
-github.com/fluxcd/pkg/ssa v0.34.0/go.mod h1:rhVh0EtYVUOznKXlz6E7JOSgdc8xWbIwA4L5HVtJRLA=
+github.com/fluxcd/pkg/ssa v0.35.0 h1:8T3WY4P9SQWApa2hq1rU1u2WE8oqP3MMTsAiEWwhmfo=
+github.com/fluxcd/pkg/ssa v0.35.0/go.mod h1:rhVh0EtYVUOznKXlz6E7JOSgdc8xWbIwA4L5HVtJRLA=
 github.com/fluxcd/pkg/testserver v0.5.0 h1:n/Iskk0tXNt2AgIgjz9qeFK/VhEXGfqeazABXZmO2Es=
 github.com/fluxcd/pkg/testserver v0.5.0/go.mod h1:/p4st6d0uPLy8wXydeF/kDJgxUYO9u2NqySuXb9S+Fo=
 github.com/fluxcd/source-controller/api v1.1.2 h1:FfKDKVWnopo+Q2pOAxgHEjrtr4MP41L8aapR4mqBhBk=

--- a/internal/action/diff_test.go
+++ b/internal/action/diff_test.go
@@ -18,6 +18,7 @@ package action
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"testing"
@@ -25,13 +26,16 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	. "github.com/onsi/gomega"
 	extjsondiff "github.com/wI2L/jsondiff"
 	helmaction "helm.sh/helm/v3/pkg/action"
 	helmrelease "helm.sh/helm/v3/pkg/release"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	apierrutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -46,8 +50,8 @@ import (
 
 func TestDiff(t *testing.T) {
 	// Normally, we would create e.g. a `suite_test.go` file with a `TestMain`
-	// function. But because this is the only test in this package which needs
-	// a test cluster, we create it here instead.
+	// function. As this is one of the few tests in this package which needs a
+	// test cluster, we create it here instead.
 	config, cleanup := newTestCluster(t)
 	t.Cleanup(func() {
 		t.Log("Stopping the test environment")
@@ -72,7 +76,7 @@ func TestDiff(t *testing.T) {
 		manifest      string
 		ignoreRules   []v2.IgnoreRule
 		mutateCluster func(objs []*unstructured.Unstructured, namespace string) ([]*unstructured.Unstructured, error)
-		want          func(namepace string) jsondiff.DiffSet
+		want          func(namespace string, desired, cluster []*unstructured.Unstructured) jsondiff.DiffSet
 		wantErr       bool
 	}{
 		{
@@ -118,16 +122,12 @@ data:
 				}
 				return clusterObjs, nil
 			},
-			want: func(namespace string) jsondiff.DiffSet {
+			want: func(namespace string, desired, cluster []*unstructured.Unstructured) jsondiff.DiffSet {
 				return jsondiff.DiffSet{
 					{
-						Type: jsondiff.DiffTypeUpdate,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "ConfigMap",
-						},
-						Namespace: namespace,
-						Name:      "changed",
+						Type:          jsondiff.DiffTypeUpdate,
+						DesiredObject: namespacedUnstructured(desired[0], namespace),
+						ClusterObject: cluster[0],
 						Patch: extjsondiff.Patch{
 							{
 								Type:     extjsondiff.OperationReplace,
@@ -138,22 +138,13 @@ data:
 						},
 					},
 					{
-						Type: jsondiff.DiffTypeCreate,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "ConfigMap",
-						},
-						Namespace: namespace,
-						Name:      "deleted",
+						Type:          jsondiff.DiffTypeCreate,
+						DesiredObject: namespacedUnstructured(desired[1], namespace),
 					},
 					{
-						Type: jsondiff.DiffTypeNone,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "ConfigMap",
-						},
-						Namespace: namespace,
-						Name:      "unchanged",
+						Type:          jsondiff.DiffTypeNone,
+						DesiredObject: namespacedUnstructured(desired[2], namespace),
+						ClusterObject: cluster[1],
 					},
 				}
 			},
@@ -185,16 +176,11 @@ data:
 				}
 				return clusterObjs, nil
 			},
-			want: func(namespace string) jsondiff.DiffSet {
+			want: func(namespace string, desired, cluster []*unstructured.Unstructured) jsondiff.DiffSet {
 				return jsondiff.DiffSet{
 					{
-						Type: jsondiff.DiffTypeExclude,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "ConfigMap",
-						},
-						Namespace: namespace,
-						Name:      "disabled",
+						Type:          jsondiff.DiffTypeExclude,
+						DesiredObject: namespacedUnstructured(desired[0], namespace),
 					},
 				}
 			},
@@ -222,16 +208,11 @@ data:
 				}
 				return clusterObjs, nil
 			},
-			want: func(namespace string) jsondiff.DiffSet {
+			want: func(namespace string, desired, cluster []*unstructured.Unstructured) jsondiff.DiffSet {
 				return jsondiff.DiffSet{
 					{
-						Type: jsondiff.DiffTypeExclude,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "ConfigMap",
-						},
-						Namespace: namespace,
-						Name:      "disabled",
+						Type:          jsondiff.DiffTypeExclude,
+						DesiredObject: namespacedUnstructured(desired[0], namespace),
 					},
 				}
 			},
@@ -299,51 +280,34 @@ data:
 				{Target: &kustomize.Selector{Name: "partially-ignored"}, Paths: []string{"/data/key"}},
 				{Paths: []string{"/data/globalKey"}},
 			},
-			want: func(namespace string) jsondiff.DiffSet {
+			want: func(namespace string, desired, cluster []*unstructured.Unstructured) jsondiff.DiffSet {
 				return jsondiff.DiffSet{
 					{
-						Type: jsondiff.DiffTypeExclude,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "ConfigMap",
-						},
-						Namespace: namespace,
-						Name:      "fully-ignored",
+						Type:          jsondiff.DiffTypeExclude,
+						DesiredObject: namespacedUnstructured(desired[0], namespace),
 					},
 					{
-						Type: jsondiff.DiffTypeUpdate,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "Secret",
-						},
-						Namespace: namespace,
-						Name:      "partially-ignored",
+						Type:          jsondiff.DiffTypeUpdate,
+						DesiredObject: namespacedUnstructured(desired[1], namespace),
+						ClusterObject: cluster[1],
 						Patch: extjsondiff.Patch{
 							{
 								Type:     extjsondiff.OperationReplace,
 								Path:     "/data/otherKey",
-								OldValue: "*** (before)",
-								Value:    "*** (after)",
+								OldValue: base64.StdEncoding.EncodeToString([]byte("changed")),
+								Value:    base64.StdEncoding.EncodeToString([]byte("otherValue")),
 							},
 						},
 					},
 					{
-						Type: jsondiff.DiffTypeNone,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "Secret",
-						},
-						Namespace: namespace,
-						Name:      "globally-ignored",
+						Type:          jsondiff.DiffTypeNone,
+						DesiredObject: namespacedUnstructured(desired[2], namespace),
+						ClusterObject: cluster[2],
 					},
 					{
-						Type: jsondiff.DiffTypeUpdate,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "ConfigMap",
-						},
-						Namespace: namespace,
-						Name:      "not-ignored",
+						Type:          jsondiff.DiffTypeUpdate,
+						DesiredObject: namespacedUnstructured(desired[3], namespace),
+						ClusterObject: cluster[3],
 						Patch: extjsondiff.Patch{
 							{
 								Type:     extjsondiff.OperationReplace,
@@ -394,68 +358,17 @@ data:
 				}
 				return clusterObjs, nil
 			},
-			want: func(namespace string) jsondiff.DiffSet {
+			want: func(namespace string, desired, cluster []*unstructured.Unstructured) jsondiff.DiffSet {
 				return jsondiff.DiffSet{
 					{
-						Type: jsondiff.DiffTypeNone,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "ConfigMap",
-						},
-						Namespace: namespace,
-						Name:      "without-namespace",
+						Type:          jsondiff.DiffTypeNone,
+						DesiredObject: namespacedUnstructured(desired[0], namespace),
+						ClusterObject: cluster[1],
 					},
 					{
-						Type: jsondiff.DiffTypeNone,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "ConfigMap",
-						},
-						Namespace: "diff-fixed-ns",
-						Name:      "with-namespace",
-					},
-				}
-			},
-		},
-		{
-			name: "masks Secret data",
-			manifest: `---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: secret
-stringData:
-  key: value`,
-			mutateCluster: func(objs []*unstructured.Unstructured, namespace string) ([]*unstructured.Unstructured, error) {
-				var clusterObjs []*unstructured.Unstructured
-				for _, obj := range objs {
-					obj := obj.DeepCopy()
-					obj.SetNamespace(namespace)
-					if err := unstructured.SetNestedField(obj.Object, "changed", "stringData", "key"); err != nil {
-						return nil, fmt.Errorf("failed to set nested field: %w", err)
-					}
-					clusterObjs = append(clusterObjs, obj)
-				}
-				return clusterObjs, nil
-			},
-			want: func(namespace string) jsondiff.DiffSet {
-				return jsondiff.DiffSet{
-					{
-						Type: jsondiff.DiffTypeUpdate,
-						GroupVersionKind: schema.GroupVersionKind{
-							Version: "v1",
-							Kind:    "Secret",
-						},
-						Namespace: namespace,
-						Name:      "secret",
-						Patch: extjsondiff.Patch{
-							{
-								Type:     extjsondiff.OperationReplace,
-								Path:     "/data/key",
-								OldValue: "*** (before)",
-								Value:    "*** (after)",
-							},
-						},
+						Type:          jsondiff.DiffTypeNone,
+						DesiredObject: namespacedUnstructured(desired[1], desired[1].GetNamespace()),
+						ClusterObject: cluster[2],
 					},
 				}
 			},
@@ -515,11 +428,346 @@ stringData:
 
 			var want jsondiff.DiffSet
 			if tt.want != nil {
-				want = tt.want(ns.Name)
+				want = tt.want(ns.Name, objs, clusterObjs)
 			}
 			if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(extjsondiff.Operation{})); diff != "" {
 				t.Errorf("Diff() mismatch (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestApplyDiff(t *testing.T) {
+	// Normally, we would create e.g. a `suite_test.go` file with a `TestMain`
+	// function. As this is one of the few tests in this package which needs a
+	// test cluster, we create it here instead.
+	config, cleanup := newTestCluster(t)
+	t.Cleanup(func() {
+		t.Log("Stopping the test environment")
+		if err := cleanup(); err != nil {
+			t.Logf("Failed to stop the test environment: %v", err)
+		}
+	})
+
+	// Construct a REST client getter for Helm's action configuration.
+	getter := kube.NewMemoryRESTClientGetter(config)
+
+	// Construct a client for to be able to mutate the cluster.
+	c, err := client.New(config, client.Options{})
+	if err != nil {
+		t.Fatalf("Failed to create client for test environment: %v", err)
+	}
+
+	const testOwner = "helm-controller"
+
+	tests := []struct {
+		name    string
+		diffSet func(namespace string) jsondiff.DiffSet
+		expect  func(g *GomegaWithT, namespace string, got *ssa.ChangeSet, err error)
+	}{
+		{
+			name: "creates and updates resources",
+			diffSet: func(namespace string) jsondiff.DiffSet {
+				return jsondiff.DiffSet{
+					{
+						Type: jsondiff.DiffTypeCreate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "Secret",
+								"metadata": map[string]interface{}{
+									"name":      "test-secret",
+									"namespace": namespace,
+								},
+								"stringData": map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+					},
+					{
+						Type: jsondiff.DiffTypeUpdate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "ConfigMap",
+								"metadata": map[string]interface{}{
+									"name":      "test-cm",
+									"namespace": namespace,
+								},
+								"data": map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+						ClusterObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "ConfigMap",
+								"metadata": map[string]interface{}{
+									"name":      "test-cm",
+									"namespace": namespace,
+								},
+								"data": map[string]interface{}{
+									"key": "changed",
+								},
+							},
+						},
+						Patch: extjsondiff.Patch{
+							{
+								Type:  extjsondiff.OperationReplace,
+								Path:  "/data/key",
+								Value: "value",
+							},
+						},
+					},
+				}
+			},
+			expect: func(g *GomegaWithT, namespace string, got *ssa.ChangeSet, err error) {
+				g.THelper()
+
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(got).NotTo(BeNil())
+				g.Expect(got.Entries).To(HaveLen(2))
+
+				g.Expect(got.Entries[0].Subject).To(Equal("Secret/" + namespace + "/test-secret"))
+				g.Expect(got.Entries[0].Action).To(Equal(ssa.CreatedAction))
+				g.Expect(c.Get(context.TODO(), types.NamespacedName{
+					Namespace: namespace,
+					Name:      "test-secret",
+				}, &corev1.Secret{})).To(Succeed())
+
+				g.Expect(got.Entries[1].Subject).To(Equal("ConfigMap/" + namespace + "/test-cm"))
+				g.Expect(got.Entries[1].Action).To(Equal(ssa.ConfiguredAction))
+				cm := &corev1.ConfigMap{}
+				g.Expect(c.Get(context.TODO(), types.NamespacedName{
+					Namespace: namespace,
+					Name:      "test-cm",
+				}, cm)).To(Succeed())
+				g.Expect(cm.Data).To(HaveKeyWithValue("key", "value"))
+			},
+		},
+		{
+			name: "continues on error",
+			diffSet: func(namespace string) jsondiff.DiffSet {
+				return jsondiff.DiffSet{
+					{
+						Type: jsondiff.DiffTypeCreate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "Secret",
+								"metadata": map[string]interface{}{
+									"name":      "invalid-test-secret",
+									"namespace": namespace,
+								},
+								"data": map[string]interface{}{
+									// Illegal base64 encoded data.
+									"key": "secret value",
+								},
+							},
+						},
+					},
+					{
+						Type: jsondiff.DiffTypeCreate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "ConfigMap",
+								"metadata": map[string]interface{}{
+									"name":      "test-cm",
+									"namespace": namespace,
+								},
+							},
+						},
+					},
+					{
+						Type: jsondiff.DiffTypeUpdate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "Secret",
+								"metadata": map[string]interface{}{
+									"name":      "invalid-test-secret-update",
+									"namespace": namespace,
+								},
+								"data": map[string]interface{}{
+									// Illegal base64 encoded data.
+									"key": "secret value2",
+								},
+							},
+						},
+						ClusterObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "Secret",
+								"metadata": map[string]interface{}{
+									"name":      "invalid-test-secret-update",
+									"namespace": namespace,
+								},
+								"stringData": map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+						Patch: extjsondiff.Patch{
+							{
+								Type: extjsondiff.OperationReplace,
+								Path: "/data/key",
+								// Illegal base64 encoded data.
+								Value: "value",
+							},
+						},
+					},
+					{
+						Type: jsondiff.DiffTypeUpdate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "ConfigMap",
+								"metadata": map[string]interface{}{
+									"name":      "test-cm-2",
+									"namespace": namespace,
+								},
+								"data": map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+						ClusterObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "ConfigMap",
+								"metadata": map[string]interface{}{
+									"name":      "test-cm-2",
+									"namespace": namespace,
+								},
+								"data": map[string]interface{}{
+									"key": "changed",
+								},
+							},
+						},
+						Patch: extjsondiff.Patch{
+							{
+								Type:  extjsondiff.OperationReplace,
+								Path:  "/data/key",
+								Value: "value",
+							},
+						},
+					},
+				}
+			},
+			expect: func(g *GomegaWithT, namespace string, got *ssa.ChangeSet, err error) {
+				g.THelper()
+
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.(apierrutil.Aggregate).Errors()).To(HaveLen(2))
+				g.Expect(err.Error()).To(ContainSubstring("invalid-test-secret creation failure"))
+				g.Expect(err.Error()).To(ContainSubstring("invalid-test-secret-update patch failure"))
+
+				// Verify that the error message does not contain the secret data.
+				g.Expect(err.Error()).ToNot(ContainSubstring("secret value"))
+				g.Expect(err.Error()).ToNot(ContainSubstring("secret value2"))
+
+				g.Expect(got).NotTo(BeNil())
+				g.Expect(got.Entries).To(HaveLen(2))
+
+				g.Expect(got.Entries[0].Subject).To(Equal("ConfigMap/" + namespace + "/test-cm"))
+				g.Expect(got.Entries[0].Action).To(Equal(ssa.CreatedAction))
+				g.Expect(c.Get(context.TODO(), types.NamespacedName{
+					Namespace: namespace,
+					Name:      "test-cm",
+				}, &corev1.ConfigMap{})).To(Succeed())
+
+				g.Expect(got.Entries[1].Subject).To(Equal("ConfigMap/" + namespace + "/test-cm-2"))
+				g.Expect(got.Entries[1].Action).To(Equal(ssa.ConfiguredAction))
+
+				cm2 := &corev1.ConfigMap{}
+				g.Expect(c.Get(context.TODO(), types.NamespacedName{
+					Namespace: namespace,
+					Name:      "test-cm-2",
+				}, cm2)).To(Succeed())
+				g.Expect(cm2.Data).To(HaveKeyWithValue("key", "value"))
+			},
+		},
+		{
+			name: "creates namespace before dependent resources",
+			diffSet: func(namespace string) jsondiff.DiffSet {
+				otherNS := generateName("test-ns")
+
+				return jsondiff.DiffSet{
+					{
+						Type: jsondiff.DiffTypeCreate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "ConfigMap",
+								"metadata": map[string]interface{}{
+									"name":      "test-cm",
+									"namespace": otherNS,
+								},
+							},
+						},
+					},
+					{
+						Type: jsondiff.DiffTypeCreate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "Namespace",
+								"metadata": map[string]interface{}{
+									"name": otherNS,
+								},
+							},
+						},
+					},
+				}
+			},
+			expect: func(g *GomegaWithT, namespace string, got *ssa.ChangeSet, err error) {
+				g.THelper()
+
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(got).NotTo(BeNil())
+				g.Expect(got.Entries).To(HaveLen(2))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			t.Cleanup(cancel)
+
+			ns, err := generateNamespace(ctx, c, "diff-action")
+			if err != nil {
+				t.Fatalf("Failed to generate namespace: %v", err)
+			}
+			t.Cleanup(func() {
+				if err := c.Delete(context.Background(), ns); client.IgnoreNotFound(err) != nil {
+					t.Logf("Failed to delete generated namespace: %v", err)
+				}
+			})
+
+			diff := tt.diffSet(ns.Name)
+
+			for _, d := range diff {
+				if d.ClusterObject != nil {
+					if err := c.Create(ctx, d.ClusterObject, client.FieldOwner(testOwner)); err != nil {
+						t.Fatalf("Failed to create cluster object: %v", err)
+					}
+					t.Cleanup(func() {
+						if err := c.Delete(ctx, d.ClusterObject); client.IgnoreNotFound(err) != nil {
+							t.Logf("Failed to delete cluster object: %v", err)
+						}
+					})
+				}
+			}
+
+			got, err := ApplyDiff(context.Background(), &helmaction.Configuration{RESTClientGetter: getter}, diff, testOwner)
+			tt.expect(g, ns.Name, got, err)
 		})
 	}
 }
@@ -551,4 +799,16 @@ func generateNamespace(ctx context.Context, c client.Client, generateName string
 		return nil, err
 	}
 	return ns, nil
+}
+
+// generateName generates a name with the given name and a random suffix.
+func generateName(name string) string {
+	return fmt.Sprintf("%s-%s", name, rand.String(5))
+}
+
+func namespacedUnstructured(obj *unstructured.Unstructured, namespace string) *unstructured.Unstructured {
+	obj = obj.DeepCopy()
+	obj.SetNamespace(namespace)
+	_ = ssa.NormalizeUnstructured(obj)
+	return obj
 }

--- a/internal/reconcile/correct_cluster_drift.go
+++ b/internal/reconcile/correct_cluster_drift.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/fluxcd/pkg/ssa"
+	"github.com/fluxcd/pkg/ssa/jsondiff"
+
+	v2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	"github.com/fluxcd/helm-controller/internal/action"
+)
+
+// CorrectClusterDrift is a reconciler that attempts to correct the cluster state
+// of a Helm release. It does so by applying the Helm release's desired state
+// to the cluster based on a jsondiff.DiffSet.
+//
+// The reconciler will only attempt to correct the cluster state if the Helm
+// release has drift detection enabled and the jsondiff.DiffSet is not empty.
+//
+// The reconciler will emit a Kubernetes event upon completion indicating
+// whether the cluster state was successfully corrected or not.
+type CorrectClusterDrift struct {
+	configFactory *action.ConfigFactory
+	eventRecorder record.EventRecorder
+	diff          jsondiff.DiffSet
+	fieldManager  string
+}
+
+func NewCorrectClusterDrift(configFactory *action.ConfigFactory, recorder record.EventRecorder, diff jsondiff.DiffSet, fieldManager string) *CorrectClusterDrift {
+	return &CorrectClusterDrift{
+		configFactory: configFactory,
+		eventRecorder: recorder,
+		diff:          diff,
+		fieldManager:  fieldManager,
+	}
+}
+
+func (r *CorrectClusterDrift) Reconcile(ctx context.Context, req *Request) error {
+	if req.Object.GetDriftDetection().GetMode() != v2.DriftDetectionEnabled || len(r.diff) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, req.Object.GetTimeout().Duration)
+	defer cancel()
+
+	changeSet, err := action.ApplyDiff(ctx, r.configFactory.Build(nil), r.diff, r.fieldManager)
+	r.report(req.Object, changeSet, err)
+	return nil
+}
+
+func (r *CorrectClusterDrift) report(obj *v2.HelmRelease, changeSet *ssa.ChangeSet, err error) {
+	cur := obj.Status.History.Latest()
+
+	switch {
+	case err != nil:
+		var sb strings.Builder
+		sb.WriteString("Failed to ")
+		if changeSet != nil && len(changeSet.Entries) > 0 {
+			sb.WriteString("partially ")
+		}
+		sb.WriteString("correct cluster state of release ")
+		sb.WriteString(cur.FullReleaseName())
+		sb.WriteString(":\n")
+		if agErr, ok := err.(apierrutil.Aggregate); ok {
+			for i := range agErr.Errors() {
+				if i > 0 {
+					sb.WriteString("\n")
+				}
+				sb.WriteString(agErr.Errors()[i].Error())
+			}
+		} else {
+			sb.WriteString(err.Error())
+		}
+
+		if changeSet != nil && len(changeSet.Entries) > 0 {
+			sb.WriteString("\n\n")
+			sb.WriteString("Successful corrections:\n")
+			sb.WriteString(changeSet.String())
+		}
+
+		r.eventRecorder.AnnotatedEventf(obj, eventMeta(cur.ChartVersion, cur.ConfigDigest), corev1.EventTypeWarning,
+			"DriftCorrectionFailed", sb.String())
+	case changeSet != nil && len(changeSet.Entries) > 0:
+		r.eventRecorder.AnnotatedEventf(obj, eventMeta(cur.ChartVersion, cur.ConfigDigest), corev1.EventTypeNormal,
+			"DriftCorrected", "Cluster state of release %s has been corrected:\n%s",
+			obj.Status.History.Latest().FullReleaseName(), changeSet.String())
+	}
+}
+
+func (r *CorrectClusterDrift) Name() string {
+	return "correct cluster drift"
+}
+
+func (r *CorrectClusterDrift) Type() ReconcilerType {
+	return ReconcilerTypeDriftCorrection
+}

--- a/internal/reconcile/correct_cluster_drift_test.go
+++ b/internal/reconcile/correct_cluster_drift_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	extjsondiff "github.com/wI2L/jsondiff"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apierrutil "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/fluxcd/pkg/ssa"
+	"github.com/fluxcd/pkg/ssa/jsondiff"
+
+	v2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	"github.com/fluxcd/helm-controller/internal/action"
+	"github.com/fluxcd/helm-controller/internal/testutil"
+)
+
+func TestCorrectClusterDrift_Reconcile(t *testing.T) {
+	mockStatus := v2.HelmReleaseStatus{
+		History: v2.Snapshots{
+			{
+				Version:   2,
+				Name:      mockReleaseName,
+				Namespace: mockReleaseNamespace,
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		obj       *v2.HelmRelease
+		diff      func(namespace string) jsondiff.DiffSet
+		wantEvent bool
+	}{
+		{
+			name: "corrects cluster drift",
+			obj: &v2.HelmRelease{
+				Spec: v2.HelmReleaseSpec{
+					DriftDetection: &v2.DriftDetection{
+						Mode: v2.DriftDetectionEnabled,
+					},
+				},
+				Status: *mockStatus.DeepCopy(),
+			},
+			diff: func(namespace string) jsondiff.DiffSet {
+				return jsondiff.DiffSet{
+					{
+						Type: jsondiff.DiffTypeCreate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "Secret",
+								"metadata": map[string]interface{}{
+									"name":      "secret",
+									"namespace": namespace,
+								},
+							},
+						},
+					},
+					{
+						Type: jsondiff.DiffTypeUpdate,
+						DesiredObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "ConfigMap",
+								"metadata": map[string]interface{}{
+									"name":      "configmap",
+									"namespace": namespace,
+								},
+								"data": map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+						ClusterObject: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"apiVersion": "v1",
+								"kind":       "ConfigMap",
+								"metadata": map[string]interface{}{
+									"name":      "configmap",
+									"namespace": namespace,
+								},
+							},
+						},
+						Patch: extjsondiff.Patch{
+							{
+								Type: extjsondiff.OperationAdd,
+								Path: "/data",
+								Value: map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+					},
+				}
+			},
+			wantEvent: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			namedNS, err := testEnv.CreateNamespace(context.TODO(), mockReleaseNamespace)
+			g.Expect(err).NotTo(HaveOccurred())
+			t.Cleanup(func() {
+				_ = testEnv.Delete(context.TODO(), namedNS)
+			})
+
+			diff := tt.diff(namedNS.Name)
+			for _, diff := range diff {
+				if diff.ClusterObject != nil {
+					obj := diff.ClusterObject.DeepCopyObject()
+					g.Expect(testEnv.Create(context.TODO(), obj.(client.Object))).To(Succeed())
+				}
+			}
+
+			getter, err := RESTClientGetterFromManager(testEnv.Manager, namedNS.Name)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			cfg, err := action.NewConfigFactory(getter, action.WithStorage(action.DefaultStorageDriver, namedNS.Name))
+			g.Expect(err).ToNot(HaveOccurred())
+
+			recorder := testutil.NewFakeRecorder(10, false)
+
+			r := NewCorrectClusterDrift(cfg, recorder, tt.diff(namedNS.Name), testFieldManager)
+			g.Expect(r.Reconcile(context.TODO(), &Request{
+				Object: tt.obj,
+			})).ToNot(HaveOccurred())
+
+			if tt.wantEvent {
+				g.Expect(recorder.GetEvents()).To(HaveLen(1))
+			} else {
+				g.Expect(recorder.GetEvents()).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestCorrectClusterDrift_report(t *testing.T) {
+	mockObj := &v2.HelmRelease{
+		Status: v2.HelmReleaseStatus{
+			History: v2.Snapshots{
+				{
+					Version:   3,
+					Name:      mockReleaseName,
+					Namespace: mockReleaseNamespace,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		obj       *v2.HelmRelease
+		changeSet *ssa.ChangeSet
+		err       error
+		wantEvent []corev1.Event
+	}{
+		{
+			name: "with multiple changes",
+			obj:  mockObj.DeepCopy(),
+			changeSet: &ssa.ChangeSet{
+				Entries: []ssa.ChangeSetEntry{
+					{
+						Subject: "Secret/namespace/name",
+						Action:  ssa.CreatedAction,
+					},
+					{
+						Subject: "Deployment/namespace/name",
+						Action:  ssa.ConfiguredAction,
+					},
+				},
+			},
+			wantEvent: []corev1.Event{
+				{
+					Type:   corev1.EventTypeNormal,
+					Reason: "DriftCorrected",
+					Message: `Cluster state of release mock-ns/mock-release.v3 has been corrected:
+Secret/namespace/name created
+Deployment/namespace/name configured`,
+				},
+			},
+		},
+		{
+			name: "with multiple changes and errors",
+			obj:  mockObj.DeepCopy(),
+			changeSet: &ssa.ChangeSet{
+				Entries: []ssa.ChangeSetEntry{
+					{
+						Subject: "Secret/namespace/name",
+						Action:  ssa.CreatedAction,
+					},
+					{
+						Subject: "Deployment/namespace/name",
+						Action:  ssa.ConfiguredAction,
+					},
+					{
+						Subject: "ConfigMap/namespace/name",
+						Action:  ssa.ConfiguredAction,
+					},
+				},
+			},
+			err: apierrutil.NewAggregate([]error{
+				errors.New("error 1"),
+				errors.New("error 2"),
+			}),
+			wantEvent: []corev1.Event{
+				{
+					Type:   corev1.EventTypeWarning,
+					Reason: "DriftCorrectionFailed",
+					Message: `Failed to partially correct cluster state of release mock-ns/mock-release.v3:
+error 1
+error 2
+
+Successful corrections:
+Secret/namespace/name created
+Deployment/namespace/name configured
+ConfigMap/namespace/name configured`,
+				},
+			},
+		},
+		{
+			name: "with multiple errors",
+			obj:  mockObj.DeepCopy(),
+			err: apierrutil.NewAggregate([]error{
+				errors.New("error 1"),
+				errors.New("error 2"),
+			}),
+			wantEvent: []corev1.Event{
+				{
+					Type:   corev1.EventTypeWarning,
+					Reason: "DriftCorrectionFailed",
+					Message: `Failed to correct cluster state of release mock-ns/mock-release.v3:
+error 1
+error 2`,
+				},
+			},
+		},
+		{
+			name: "with single change",
+			obj:  mockObj.DeepCopy(),
+			changeSet: &ssa.ChangeSet{
+				Entries: []ssa.ChangeSetEntry{
+					{
+						Subject: "Secret/namespace/name",
+						Action:  ssa.CreatedAction,
+					},
+				},
+			},
+			wantEvent: []corev1.Event{
+				{
+					Type:   corev1.EventTypeNormal,
+					Reason: "DriftCorrected",
+					Message: `Cluster state of release mock-ns/mock-release.v3 has been corrected:
+Secret/namespace/name created`,
+				},
+			},
+		},
+		{
+			name: "with single error",
+			obj:  mockObj.DeepCopy(),
+			err:  errors.New("error 1"),
+			wantEvent: []corev1.Event{
+				{
+					Type:   corev1.EventTypeWarning,
+					Reason: "DriftCorrectionFailed",
+					Message: `Failed to correct cluster state of release mock-ns/mock-release.v3:
+error 1`,
+				},
+			},
+		},
+		{
+			name:      "empty change set",
+			obj:       mockObj.DeepCopy(),
+			wantEvent: []corev1.Event{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			recorder := testutil.NewFakeRecorder(10, false)
+			r := &CorrectClusterDrift{
+				eventRecorder: recorder,
+			}
+
+			r.report(tt.obj, tt.changeSet, tt.err)
+			g.Expect(recorder.GetEvents()).To(ConsistOf(tt.wantEvent))
+		})
+	}
+}

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -38,6 +38,9 @@ const (
 	// release in a stale pending state. It differs from ReconcilerTypeRemediate
 	// in that it does not produce a new Helm release.
 	ReconcilerTypeUnlock ReconcilerType = "unlock"
+	// ReconcilerTypeDriftCorrection is an ActionReconciler which corrects
+	// Helm releases which have drifted from the cluster state.
+	ReconcilerTypeDriftCorrection ReconcilerType = "drift correction"
 )
 
 // ReconcilerType is a string which identifies the type of ActionReconciler.

--- a/internal/reconcile/release_test.go
+++ b/internal/reconcile/release_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package reconcile
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -35,23 +34,6 @@ const (
 	mockReleaseName      = "mock-release"
 	mockReleaseNamespace = "mock-ns"
 )
-
-func Test_observedReleases_sortedVersions(t *testing.T) {
-	tests := []struct {
-		name         string
-		r            observedReleases
-		wantVersions []int
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if gotVersions := tt.r.sortedVersions(); !reflect.DeepEqual(gotVersions, tt.wantVersions) {
-				t.Errorf("sortedVersions() = %v, want %v", gotVersions, tt.wantVersions)
-			}
-		})
-	}
-}
 
 func Test_summarize(t *testing.T) {
 	tests := []struct {

--- a/internal/reconcile/state_test.go
+++ b/internal/reconcile/state_test.go
@@ -525,6 +525,13 @@ func TestDetermineReleaseState_DriftDetection(t *testing.T) {
 										"name":              "fixture",
 										"namespace":         namespace,
 										"creationTimestamp": nil,
+										"labels": map[string]interface{}{
+											"app.kubernetes.io/managed-by": "Helm",
+										},
+										"annotations": map[string]interface{}{
+											"meta.helm.sh/release-name":      mockReleaseName,
+											"meta.helm.sh/release-namespace": namespace,
+										},
 									},
 								},
 							},
@@ -558,6 +565,13 @@ func TestDetermineReleaseState_DriftDetection(t *testing.T) {
 										"name":              "fixture",
 										"namespace":         namespace,
 										"creationTimestamp": nil,
+										"labels": map[string]interface{}{
+											"app.kubernetes.io/managed-by": "Helm",
+										},
+										"annotations": map[string]interface{}{
+											"meta.helm.sh/release-name":      mockReleaseName,
+											"meta.helm.sh/release-namespace": namespace,
+										},
 									},
 								},
 							},
@@ -611,6 +625,13 @@ func TestDetermineReleaseState_DriftDetection(t *testing.T) {
 				for _, obj := range objs {
 					g.Expect(ssa.NormalizeUnstructured(obj)).To(Succeed())
 					obj.SetNamespace(releaseNamespace)
+					obj.SetLabels(map[string]string{
+						"app.kubernetes.io/managed-by": "Helm",
+					})
+					obj.SetAnnotations(map[string]string{
+						"meta.helm.sh/release-name":      rls.Name,
+						"meta.helm.sh/release-namespace": rls.Namespace,
+					})
 					g.Expect(testEnv.Create(context.Background(), obj)).To(Succeed())
 				}
 			}

--- a/internal/reconcile/state_test.go
+++ b/internal/reconcile/state_test.go
@@ -27,7 +27,7 @@ import (
 	helmrelease "helm.sh/helm/v3/pkg/release"
 	helmstorage "helm.sh/helm/v3/pkg/storage"
 	helmdriver "helm.sh/helm/v3/pkg/storage/driver"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/fluxcd/pkg/ssa/jsondiff"
@@ -517,12 +517,17 @@ func TestDetermineReleaseState_DriftDetection(t *testing.T) {
 					Diff: jsondiff.DiffSet{
 						{
 							Type: jsondiff.DiffTypeCreate,
-							GroupVersionKind: schema.GroupVersionKind{
-								Kind:    "Secret",
-								Version: "v1",
+							DesiredObject: &unstructured.Unstructured{
+								Object: map[string]interface{}{
+									"apiVersion": "v1",
+									"kind":       "Secret",
+									"metadata": map[string]interface{}{
+										"name":              "fixture",
+										"namespace":         namespace,
+										"creationTimestamp": nil,
+									},
+								},
 							},
-							Namespace: namespace,
-							Name:      "fixture",
 						},
 					},
 				}
@@ -545,12 +550,17 @@ func TestDetermineReleaseState_DriftDetection(t *testing.T) {
 					Diff: jsondiff.DiffSet{
 						{
 							Type: jsondiff.DiffTypeCreate,
-							GroupVersionKind: schema.GroupVersionKind{
-								Kind:    "Secret",
-								Version: "v1",
+							DesiredObject: &unstructured.Unstructured{
+								Object: map[string]interface{}{
+									"apiVersion": "v1",
+									"kind":       "Secret",
+									"metadata": map[string]interface{}{
+										"name":              "fixture",
+										"namespace":         namespace,
+										"creationTimestamp": nil,
+									},
+								},
 							},
-							Namespace: namespace,
-							Name:      "fixture",
 						},
 					},
 				}


### PR DESCRIPTION
This changes the cluster drift correction behavior from performing a
Helm upgrade to performing create and patch API requests based on the
JSON Patch data.

Doing this is much lighter than performing a full release cycle, and
deals with the issue of Helm being unable to restore state of Custom
Resources without the `--force` flag being set. Which has unwanted
side-effects like forcing objects through a deletion/creation cycle.

After a drift correction attempt a Kubernetes Event is emitted, which
contains a summary of the created and patched resources, and a
collection of any (potential) errors.

As the goal is to restore state as best as we can, the drift correction
will be re-attempted until all resources have been restored to the
desired state.

Fixes #805