### PR TITLE
reconcile: remove stale `TestSuccess` condition

### DIFF
--- a/internal/reconcile/install.go
+++ b/internal/reconcile/install.go
@@ -84,7 +84,8 @@ func (r *Install) Reconcile(ctx context.Context, req *Request) error {
 	// before the install.
 	req.Object.Status.ClearHistory()
 
-	// If we are installing, we are no longer remediated.
+	// If we are installing, none of the previous conditions apply.
+	conditions.Delete(req.Object, v2.TestSuccessCondition)
 	conditions.Delete(req.Object, v2.RemediatedCondition)
 
 	// Run the Helm install action.

--- a/internal/reconcile/upgrade.go
+++ b/internal/reconcile/upgrade.go
@@ -75,7 +75,8 @@ func (r *Upgrade) Reconcile(ctx context.Context, req *Request) error {
 	// Mark upgrade attempt on object.
 	req.Object.Status.LastAttemptedReleaseAction = v2.ReleaseActionUpgrade
 
-	// If we are upgrading, we are no longer remediated.
+	// If we are upgrading, none of the previous conditions apply.
+	conditions.Delete(req.Object, v2.TestSuccessCondition)
 	conditions.Delete(req.Object, v2.RemediatedCondition)
 
 	// Run the Helm upgrade action.


### PR DESCRIPTION
When a Helm install or upgrade is performed, to prevent confusion due to reporting a stale test result.