### PR TITLE
reconcile: do not emit HelmChartInSync event

### DIFF
--- a/internal/reconcile/helmchart_template.go
+++ b/internal/reconcile/helmchart_template.go
@@ -149,7 +149,6 @@ func (r *HelmChartTemplate) Reconcile(ctx context.Context, req *Request) error {
 			newChart.Spec.SourceRef.Kind, newChart.GetNamespace(), newChart.Spec.SourceRef.Name)
 
 		ctrl.LoggerFrom(ctx).Info(msg)
-		r.eventRecorder.Eventf(req.Object, eventv1.EventTypeTrace, "HelmChartInSync", msg)
 	default:
 		err = fmt.Errorf("unexpected action '%s' for %s", entry.Action.String(), entry.Subject)
 		return err


### PR DESCRIPTION
Due to the frequency, this would otherwise suppress other Kubernetes Events which are more important. Especially when the `.spec.interval` of the HelmRelease is set to a low value.