### PR TITLE
api: deprecate stragic merge and JSON 6902 patches

### DIFF
--- a/api/v2beta2/helmrelease_types.go
+++ b/api/v2beta2/helmrelease_types.go
@@ -50,10 +50,12 @@ type Kustomize struct {
 	Patches []kustomize.Patch `json:"patches,omitempty"`
 
 	// Strategic merge patches, defined as inline YAML objects.
+	// Deprecated: use Patches instead.
 	// +optional
 	PatchesStrategicMerge []apiextensionsv1.JSON `json:"patchesStrategicMerge,omitempty"`
 
 	// JSON 6902 patches, defined as inline YAML objects.
+	// Deprecated: use Patches instead.
 	// +optional
 	PatchesJSON6902 []kustomize.JSON6902Patch `json:"patchesJson6902,omitempty"`
 

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -1529,7 +1529,8 @@ spec:
                             type: object
                           type: array
                         patchesJson6902:
-                          description: JSON 6902 patches, defined as inline YAML objects.
+                          description: 'JSON 6902 patches, defined as inline YAML
+                            objects. Deprecated: use Patches instead.'
                           items:
                             description: JSON6902Patch contains a JSON6902 patch and
                               the target the patch should be applied to.
@@ -1624,8 +1625,8 @@ spec:
                             type: object
                           type: array
                         patchesStrategicMerge:
-                          description: Strategic merge patches, defined as inline
-                            YAML objects.
+                          description: 'Strategic merge patches, defined as inline
+                            YAML objects. Deprecated: use Patches instead.'
                           items:
                             x-kubernetes-preserve-unknown-fields: true
                           type: array

--- a/docs/api/v2beta2/helm.md
+++ b/docs/api/v2beta2/helm.md
@@ -1897,7 +1897,8 @@ capable of targeting objects based on kind, label and annotation selectors.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Strategic merge patches, defined as inline YAML objects.</p>
+<p>Strategic merge patches, defined as inline YAML objects.
+Deprecated: use Patches instead.</p>
 </td>
 </tr>
 <tr>
@@ -1911,7 +1912,8 @@ capable of targeting objects based on kind, label and annotation selectors.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>JSON 6902 patches, defined as inline YAML objects.</p>
+<p>JSON 6902 patches, defined as inline YAML objects.
+Deprecated: use Patches instead.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
They have been deprecated for a long time, and should be scheduled for removal to ensure they can be removed in the final `v2` release.

xref: https://github.com/fluxcd/helm-controller/pull/828#discussion_r1417265898