### PR TITLE
ci: increase timeout delete-ns tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -538,10 +538,11 @@ jobs:
           kubectl -n delete-ns wait helmreleases/podinfo --for=condition=ready --timeout=2m
           kubectl delete ns delete-ns 1>/dev/null 2>&1 &
           echo -n ">>> Waiting for namespace to be deleted"
-          if kubectl wait --for=delete namespace delete-ns --timeout=3m; then
+          if kubectl wait --for=delete namespace delete-ns --timeout=5m; then
             echo ' Namespace deleted successfully'
           else
             echo ' Timed out waiting for namespace to be deleted'
+            kubectl get all -n delete-ns
             exit 1
           fi
       - name: Run post-renderer-kustomize test


### PR DESCRIPTION
This test has shown to be a flake on multiple ocassions.

After running it locally a dozen of times, my conclusion is that the
time it takes for Kubernetes to shutdown a Pod may sometimes be a tiny
bit longer than anticipated by the current timeout.

Therefore, increase it to 5 minutes and provide more context on the
state of the namespace in case a timeout occurs.