### PR TITLE
controller: address test flake

### DIFF
--- a/internal/controller/helmrelease_controller_test.go
+++ b/internal/controller/helmrelease_controller_test.go
@@ -852,12 +852,14 @@ func TestHelmReleaseReconciler_reconcileDelete(t *testing.T) {
 		g.Expect(err).To(MatchError(helmdriver.ErrReleaseNotFound))
 
 		// Verify Helm chart has been removed.
-		err = testEnv.Get(context.TODO(), client.ObjectKey{
-			Namespace: hc.Namespace,
-			Name:      hc.Name,
-		}, &sourcev1b2.HelmChart{})
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		g.Eventually(func(g Gomega) {
+			err = testEnv.Get(context.TODO(), client.ObjectKey{
+				Namespace: hc.Namespace,
+				Name:      hc.Name,
+			}, &sourcev1b2.HelmChart{})
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}).Should(Succeed())
 	})
 
 	t.Run("removes finalizer for suspended resource with DeletionTimestamp", func(t *testing.T) {


### PR DESCRIPTION
As the Kubernetes client used in tests is cache backed, it can take a tiny bit of time for the client to actually notice the removal.

Wrapping in `Eventually` should address this.

As observed in https://github.com/fluxcd/helm-controller/actions/runs/7169853780/job/19521199735