### PR TITLE
api: ensure backwards compatibility v2beta1

### DIFF
--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -156,6 +156,15 @@ type HelmReleaseSpec struct {
 	// +optional
 	PersistentClient *bool `json:"persistentClient,omitempty"`
 
+	// DriftDetection holds the configuration for detecting and handling
+	// differences between the manifest in the Helm storage and the resources
+	// currently existing in the cluster.
+	//
+	// Note: this field is provisional to the v2beta2 API, and not actively used
+	// by v2beta1 HelmReleases.
+	// +optional
+	DriftDetection *v2beta2.DriftDetection `json:"driftDetection,omitempty"`
+
 	// Install holds the configuration for Helm install actions for this HelmRelease.
 	// +optional
 	Install *Install `json:"install,omitempty"`
@@ -947,6 +956,22 @@ type HelmReleaseStatus struct {
 	// by v2beta1 HelmReleases.
 	// +optional
 	LastAttemptedReleaseAction string `json:"lastAttemptedReleaseAction,omitempty"`
+
+	// LastHandledForceAt holds the value of the most recent force request
+	// value, so a change of the annotation value can be detected.
+	//
+	// Note: this field is provisional to the v2beta2 API, and not actively used
+	// by v2beta1 HelmReleases.
+	// +optional
+	LastHandledForceAt string `json:"lastHandledForceAt,omitempty"`
+
+	// LastHandledResetAt holds the value of the most recent reset request
+	// value, so a change of the annotation value can be detected.
+	//
+	// Note: this field is provisional to the v2beta2 API, and not actively used
+	// by v2beta1 HelmReleases.
+	// +optional
+	LastHandledResetAt string `json:"lastHandledResetAt,omitempty"`
 }
 
 // GetHelmChart returns the namespace and name of the HelmChart.

--- a/api/v2beta1/zz_generated.deepcopy.go
+++ b/api/v2beta1/zz_generated.deepcopy.go
@@ -235,6 +235,11 @@ func (in *HelmReleaseSpec) DeepCopyInto(out *HelmReleaseSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DriftDetection != nil {
+		in, out := &in.DriftDetection, &out.DriftDetection
+		*out = new(v2beta2.DriftDetection)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Install != nil {
 		in, out := &in.Install, &out.Install
 		*out = new(Install)

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -199,6 +199,82 @@ spec:
                   - name
                   type: object
                 type: array
+              driftDetection:
+                description: "DriftDetection holds the configuration for detecting
+                  and handling differences between the manifest in the Helm storage
+                  and the resources currently existing in the cluster. \n Note: this
+                  field is provisional to the v2beta2 API, and not actively used by
+                  v2beta1 HelmReleases."
+                properties:
+                  ignore:
+                    description: Ignore contains a list of rules for specifying which
+                      changes to ignore during diffing.
+                    items:
+                      description: IgnoreRule defines a rule to selectively disregard
+                        specific changes during the drift detection process.
+                      properties:
+                        paths:
+                          description: Paths is a list of JSON Pointer (RFC 6901)
+                            paths to be excluded from consideration in a Kubernetes
+                            object.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: Target is a selector for specifying Kubernetes
+                            objects to which this rule applies. If Target is not set,
+                            the Paths will be ignored for all Kubernetes objects within
+                            the manifest of the Helm release.
+                          properties:
+                            annotationSelector:
+                              description: AnnotationSelector is a string that follows
+                                the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: Group is the API group to select resources
+                                from. Together with Version and Kind it is capable
+                                of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: Kind of the API Group to select resources
+                                from. Together with Group and Version it is capable
+                                of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: LabelSelector is a string that follows
+                                the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: Version of the API Group to select resources
+                                from. Together with Group and Kind it is capable of
+                                unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  mode:
+                    description: Mode defines how differences should be handled between
+                      the Helm manifest and the manifest currently applied to the
+                      cluster. If not explicitly set, it defaults to DiffModeDisabled.
+                    enum:
+                    - enabled
+                    - warn
+                    - disabled
+                    type: string
+                type: object
               install:
                 description: Install holds the configuration for Helm install actions
                   for this HelmRelease.
@@ -1011,10 +1087,22 @@ spec:
                 description: LastAttemptedValuesChecksum is the SHA1 checksum of the
                   values of the last reconciliation attempt.
                 type: string
+              lastHandledForceAt:
+                description: "LastHandledForceAt holds the value of the most recent
+                  force request value, so a change of the annotation value can be
+                  detected. \n Note: this field is provisional to the v2beta2 API,
+                  and not actively used by v2beta1 HelmReleases."
+                type: string
               lastHandledReconcileAt:
                 description: LastHandledReconcileAt holds the value of the most recent
                   reconcile request value, so a change of the annotation value can
                   be detected.
+                type: string
+              lastHandledResetAt:
+                description: "LastHandledResetAt holds the value of the most recent
+                  reset request value, so a change of the annotation value can be
+                  detected. \n Note: this field is provisional to the v2beta2 API,
+                  and not actively used by v2beta1 HelmReleases."
                 type: string
               lastReleaseRevision:
                 description: LastReleaseRevision is the revision of the last successful


### PR DESCRIPTION
As we are (still) not making use of conversion webhooks, new fields can only be introduced by including them in all served API versions. As otherwise conversion will fail.

Fix: https://github.com/fluxcd/flux2/issues/4479