### PR TITLE
Properly configure namespace selector

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,8 +228,10 @@ func main() {
 		},
 	}
 
-	mgrConfig.Cache.DefaultNamespaces = map[string]ctrlcache.Config{
-		watchNamespace: {},
+	if watchNamespace != "" {
+		mgrConfig.Cache.DefaultNamespaces = map[string]ctrlcache.Config{
+			watchNamespace: ctrlcache.Config{},
+		}
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, mgrConfig)


### PR DESCRIPTION
This accidentally did not get `if`-wrapped in
eaa2a8c2fe78e3b7d5aa9fcedc7757b3c4005f51, breaking the configuration option to watch a single namespace, and thereby as by-effect the breakage of sharding.

Fixes https://github.com/fluxcd/flux2/issues/4500