### PR TITLE
Loosen dependency check

### DIFF
--- a/internal/controller/helmrelease_controller.go
+++ b/internal/controller/helmrelease_controller.go
@@ -533,7 +533,7 @@ func (r *HelmReleaseReconciler) checkDependencies(ctx context.Context, obj *v2.H
 			return fmt.Errorf("unable to get '%s' dependency: %w", ref, err)
 		}
 
-		if dHr.Generation != dHr.Status.ObservedGeneration || !conditions.IsTrue(dHr, meta.ReadyCondition) {
+		if !conditions.IsTrue(dHr, meta.ReadyCondition) {
 			return fmt.Errorf("dependency '%s' is not ready", ref)
 		}
 	}


### PR DESCRIPTION
Dependency checks do not account for upgrade ordering (as documented in the API spec), so we only care about having the `Ready` condition set to `True`, no matter the observed generation.

Possible fix for: https://github.com/fluxcd/flux2/issues/4524