### PR TITLE
feat: emitting events when reconciliation starts

### DIFF
--- a/api/v2beta2/condition_types.go
+++ b/api/v2beta2/condition_types.go
@@ -32,6 +32,10 @@ const (
 )
 
 const (
+	// InstallStartedReason represents the fact that the Helm install for the
+	// HelmRelease started.
+	InstallStartedReason string = "InstallStarted"
+
 	// InstallSucceededReason represents the fact that the Helm install for the
 	// HelmRelease succeeded.
 	InstallSucceededReason string = "InstallSucceeded"
@@ -39,6 +43,10 @@ const (
 	// InstallFailedReason represents the fact that the Helm install for the
 	// HelmRelease failed.
 	InstallFailedReason string = "InstallFailed"
+
+	// UpgradeStartedReason represents the fact that the Helm upgrade for the
+	// HelmRelease started.
+	UpgradeStartedReason string = "UpgradeStarted"
 
 	// UpgradeSucceededReason represents the fact that the Helm upgrade for the
 	// HelmRelease succeeded.
@@ -48,6 +56,10 @@ const (
 	// HelmRelease failed.
 	UpgradeFailedReason string = "UpgradeFailed"
 
+	// TestStartedReason represents the fact that the Helm tests for the
+	// HelmRelease started.
+	TestStartedReason string = "TestStarted"
+
 	// TestSucceededReason represents the fact that the Helm tests for the
 	// HelmRelease succeeded.
 	TestSucceededReason string = "TestSucceeded"
@@ -56,6 +68,10 @@ const (
 	// failed.
 	TestFailedReason string = "TestFailed"
 
+	// RollbackStartedReason represents the fact that the Helm rollback for the
+	// HelmRelease started.
+	RollbackStartedReason string = "RollbackStarted"
+
 	// RollbackSucceededReason represents the fact that the Helm rollback for the
 	// HelmRelease succeeded.
 	RollbackSucceededReason string = "RollbackSucceeded"
@@ -63,6 +79,10 @@ const (
 	// RollbackFailedReason represents the fact that the Helm test for the
 	// HelmRelease failed.
 	RollbackFailedReason string = "RollbackFailed"
+
+	// UninstallStartedReason represents the fact that the Helm uninstall for the
+	// HelmRelease started.
+	UninstallStartedReason string = "UninstallStarted"
 
 	// UninstallSucceededReason represents the fact that the Helm uninstall for the
 	// HelmRelease succeeded.

--- a/internal/reconcile/test_test.go
+++ b/internal/reconcile/test_test.go
@@ -30,7 +30,6 @@ import (
 	helmdriver "helm.sh/helm/v3/pkg/storage/driver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
 
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
@@ -96,6 +95,9 @@ func TestTest_Reconcile(t *testing.T) {
 		// expectedConditions are the conditions that are expected to be set on
 		// the HelmRelease after running test.
 		expectConditions []metav1.Condition
+		// expectEvents is the expected Events of the HelmRelease
+		// after running tests.
+		expectEvents func(cur *v2.Snapshot) []corev1.Event
 		// expectHistory is the expected History on the HelmRelease after
 		// running test.
 		expectHistory func(releases []*helmrelease.Release) v2.Snapshots
@@ -134,6 +136,21 @@ func TestTest_Reconcile(t *testing.T) {
 				*conditions.TrueCondition(v2.TestSuccessCondition, v2.TestSucceededReason,
 					"1 test hook completed successfully"),
 			},
+			expectEvents: func(cur *v2.Snapshot) []corev1.Event {
+				return []corev1.Event{
+					{
+						Type:    corev1.EventTypeNormal,
+						Reason:  v2.TestStartedReason,
+						Message: fmt.Sprintf(fmtTestStarted, cur.FullReleaseName(), cur.VersionedChartName()),
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								eventMetaGroupKey(eventv1.MetaRevisionKey): cur.ChartVersion,
+								eventMetaGroupKey(eventv1.MetaTokenKey):    cur.ConfigDigest,
+							},
+						},
+					},
+				}
+			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				withTests := release.ObservedToSnapshot(release.ObserveRelease(releases[0]))
 				withTests.SetTestHooks(release.TestHooksFromRelease(releases[0]))
@@ -165,6 +182,21 @@ func TestTest_Reconcile(t *testing.T) {
 					"no test hooks"),
 				*conditions.TrueCondition(v2.TestSuccessCondition, v2.TestSucceededReason,
 					"no test hooks"),
+			},
+			expectEvents: func(cur *v2.Snapshot) []corev1.Event {
+				return []corev1.Event{
+					{
+						Type:    corev1.EventTypeNormal,
+						Reason:  v2.TestStartedReason,
+						Message: fmt.Sprintf(fmtTestStarted, cur.FullReleaseName(), cur.VersionedChartName()),
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								eventMetaGroupKey(eventv1.MetaRevisionKey): cur.ChartVersion,
+								eventMetaGroupKey(eventv1.MetaTokenKey):    cur.ConfigDigest,
+							},
+						},
+					},
+				}
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				withTests := release.ObservedToSnapshot(release.ObserveRelease(releases[0]))
@@ -199,6 +231,21 @@ func TestTest_Reconcile(t *testing.T) {
 					"timed out waiting for the condition"),
 				*conditions.FalseCondition(v2.TestSuccessCondition, v2.TestFailedReason,
 					"timed out waiting for the condition"),
+			},
+			expectEvents: func(cur *v2.Snapshot) []corev1.Event {
+				return []corev1.Event{
+					{
+						Type:    corev1.EventTypeNormal,
+						Reason:  v2.TestStartedReason,
+						Message: fmt.Sprintf(fmtTestStarted, cur.FullReleaseName(), cur.VersionedChartName()),
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								eventMetaGroupKey(eventv1.MetaRevisionKey): cur.ChartVersion,
+								eventMetaGroupKey(eventv1.MetaTokenKey):    cur.ConfigDigest,
+							},
+						},
+					},
+				}
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				withTests := release.ObservedToSnapshot(release.ObserveRelease(releases[0]))
@@ -256,6 +303,21 @@ func TestTest_Reconcile(t *testing.T) {
 					ErrReleaseMismatch.Error()),
 				*conditions.FalseCondition(v2.TestSuccessCondition, v2.TestFailedReason,
 					ErrReleaseMismatch.Error()),
+			},
+			expectEvents: func(cur *v2.Snapshot) []corev1.Event {
+				return []corev1.Event{
+					{
+						Type:    corev1.EventTypeNormal,
+						Reason:  v2.TestStartedReason,
+						Message: fmt.Sprintf(fmtTestStarted, cur.FullReleaseName(), cur.VersionedChartName()),
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								eventMetaGroupKey(eventv1.MetaRevisionKey): cur.ChartVersion,
+								eventMetaGroupKey(eventv1.MetaTokenKey):    cur.ConfigDigest,
+							},
+						},
+					},
+				}
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
@@ -318,7 +380,7 @@ func TestTest_Reconcile(t *testing.T) {
 				cfg.Driver = tt.driver(cfg.Driver)
 			}
 
-			recorder := new(record.FakeRecorder)
+			recorder := testutil.NewFakeRecorder(10, true)
 			got := (NewTest(cfg, recorder)).Reconcile(context.TODO(), &Request{
 				Object: obj,
 			})
@@ -328,6 +390,12 @@ func TestTest_Reconcile(t *testing.T) {
 				g.Expect(got).ToNot(HaveOccurred())
 			}
 
+			if tt.expectEvents != nil {
+				cur := obj.Status.History.Latest().DeepCopy()
+				for _, event := range tt.expectEvents(cur) {
+					g.Expect(recorder.GetEvents()).To(ContainElement(event))
+				}
+			}
 			g.Expect(obj.Status.Conditions).To(conditions.MatchConditions(tt.expectConditions))
 
 			releases, _ = store.History(mockReleaseName)


### PR DESCRIPTION
This is the improvement related to the issue #889 
The PR adds the event emitting before the Install/Upgrade/Uninstall/Rollback/Test/Unlock/Remediation reconciliation starts. 
I also added the corresponding tests to every reconciliation process. 
Please take a look at the changes!
I'll be happy to read any advice, concerns, or remarks. 