### PR TITLE
Add support for `HelmChart` as chartRef

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -138,6 +138,11 @@ jobs:
           kubectl -n install-create-target-ns get deployment install-create-target-ns-install-create-target-ns-podinfo
 
           kubectl -n helm-system delete -f config/testdata/install-create-target-ns
+      - name: Run install from helmChart test
+        run: |
+          kubectl -n helm-system apply -f config/testdata/install-from-hc-source
+          kubectl -n helm-system wait helmreleases/podinfo-from-hc --for=condition=ready --timeout=4m
+          kubectl -n helm-system delete -f config/testdata/install-from-hc-source
       - name: Run install from ocirepo test
         run: |
           kubectl -n helm-system apply -f config/testdata/install-from-ocirepo-source

--- a/api/v2beta2/reference_types.go
+++ b/api/v2beta2/reference_types.go
@@ -50,7 +50,7 @@ type CrossNamespaceSourceReference struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 
 	// Kind of the referent.
-	// +kubebuilder:validation:Enum=OCIRepository
+	// +kubebuilder:validation:Enum=OCIRepository;HelmChart
 	// +required
 	Kind string `json:"kind"`
 

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -1436,6 +1436,7 @@ spec:
                     description: Kind of the referent.
                     enum:
                     - OCIRepository
+                    - HelmChart
                     type: string
                   name:
                     description: Name of the referent.

--- a/config/testdata/install-from-hc-source/test.yaml
+++ b/config/testdata/install-from-hc-source/test.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmChart
+metadata:
+  name: podinfo-hc
+spec:
+  chart: podinfo
+  version: '6.2.1'
+  sourceRef:
+    kind: HelmRepository
+    name: podinfo-oci
+  interval: 30s
+  verify:
+    provider: cosign
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: podinfo-from-hc
+spec:
+  chartRef:
+    kind: HelmChart
+    name: podinfo-hc
+  interval: 30s
+  values:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi

--- a/docs/spec/v2beta2/helmreleases.md
+++ b/docs/spec/v2beta2/helmreleases.md
@@ -205,16 +205,17 @@ HelmRelease object.
 
 ### Chart reference
 
-`.spec.chartRef` is an optional field used to refer to an [OCIRepository resource](https://fluxcd.io/flux/components/source/ocirepositories/)
+`.spec.chartRef` is an optional field used to refer to an [OCIRepository resource](https://fluxcd.io/flux/components/source/ocirepositories/) or a [HelmChart resource](https://fluxcd.io/flux/components/source/helmcharts/)
 from which to fetch the Helm chart. The chart is fetched by the controller with the
-information provided by `.status.artifact` of the OCIRepository.
+information provided by `.status.artifact` of the referenced resource.
 
-The chart version of the last release attempt is reported in `.status.lastAttemptedRevision`.
-The version is in the format `<version>+<digest[0:12]>`. The digest of the OCI artifact
-is appended to the version to ensure that a change in the artifact content triggers
-a new release. The controller will automatically perform a Helm upgrade when the
-OCIRepository detects a new digest in the OCI artifact stored in registry, even if
-the version inside `Chart.yaml` is unchanged.
+For a referenced resource of `kind OCIRepository`, the chart version of the last
+release attempt is reported in `.status.lastAttemptedRevision`. The version is in
+the format `<version>+<digest[0:12]>`. The digest of the OCI artifact is appended
+to the version to ensure that a change in the artifact content triggers a new release.
+The controller will automatically perform a Helm upgrade when the `OCIRepository`
+detects a new digest in the OCI artifact stored in registry, even if the version
+inside `Chart.yaml` is unchanged.
 
 **Warning:** One of `.spec.chart` or `.spec.chartRef` must be set, but not both.
 When switching from `.spec.chart` to `.spec.chartRef`, the controller will perform
@@ -224,6 +225,8 @@ an Helm upgrade and will garbage collect the old HelmChart object.
 references with the `--no-cross-namespace-refs=true` controller flag. When this flag is
 set, the HelmRelease can only refer to OCIRepositories in the same namespace as the
 HelmRelease object.
+
+#### OCIRepository reference example
 
 ```yaml
 apiVersion: source.toolkit.fluxcd.io/v1beta2
@@ -236,6 +239,38 @@ spec:
   url: oci://ghcr.io/stefanprodan/charts/podinfo
   ref:
     tag: 6.6.0
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  interval: 10m
+  chartRef:
+    kind: OCIRepository
+    name: podinfo
+    namespace: default
+  values:
+    replicaCount: 2
+```
+
+#### HelmChart reference example
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmChart
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  interval: 5m0s
+  chart: podinfo
+  reconcileStrategy: ChartVersion
+  sourceRef:
+    kind: HelmRepository
+    name: podinfo
+  version: '5.*'
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease

--- a/docs/spec/v2beta2/helmreleases.md
+++ b/docs/spec/v2beta2/helmreleases.md
@@ -280,7 +280,7 @@ metadata:
 spec:
   interval: 10m
   chartRef:
-    kind: OCIRepository
+    kind: HelmChart
     name: podinfo
     namespace: default
   values:


### PR DESCRIPTION
If implemented, user will be able to share an existing HelmChart custom resource between HelmReleases.

Closes: https://github.com/fluxcd/helm-controller/issues/204

Followup: #905