### PR TITLE
Add the chart app version to status and events metadata

### DIFF
--- a/api/v2/snapshot_types.go
+++ b/api/v2/snapshot_types.go
@@ -138,6 +138,9 @@ type Snapshot struct {
 	// storage.
 	// +required
 	ChartVersion string `json:"chartVersion"`
+	// AppVersion is the chart app version of the release object in storage.
+	// +optional
+	AppVersion string `json:"appVersion,omitempty"`
 	// ConfigDigest is the checksum of the config (better known as
 	// "values") of the release object in storage.
 	// It has the format of `<algo>:<checksum>`.

--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fluxcd/pkg/apis/kustomize"
 	"github.com/fluxcd/pkg/apis/meta"
 
+	v2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/helm-controller/api/v2beta2"
 )
 
@@ -931,7 +932,7 @@ type HelmReleaseStatus struct {
 	// Note: this field is provisional to the v2beta2 API, and not actively used
 	// by v2beta1 HelmReleases.
 	// +optional
-	History v2beta2.Snapshots `json:"history,omitempty"`
+	History v2.Snapshots `json:"history,omitempty"`
 
 	// LastAttemptedGeneration is the last generation the controller attempted
 	// to reconcile.

--- a/api/v2beta1/zz_generated.deepcopy.go
+++ b/api/v2beta1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v2beta1
 
 import (
+	"github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/helm-controller/api/v2beta2"
 	"github.com/fluxcd/pkg/apis/kustomize"
 	"github.com/fluxcd/pkg/apis/meta"
@@ -306,11 +307,11 @@ func (in *HelmReleaseStatus) DeepCopyInto(out *HelmReleaseStatus) {
 	}
 	if in.History != nil {
 		in, out := &in.History, &out.History
-		*out = make(v2beta2.Snapshots, len(*in))
+		*out = make(v2.Snapshots, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {
 				in, out := &(*in)[i], &(*out)[i]
-				*out = new(v2beta2.Snapshot)
+				*out = new(v2.Snapshot)
 				(*in).DeepCopyInto(*out)
 			}
 		}

--- a/api/v2beta2/helmrelease_types.go
+++ b/api/v2beta2/helmrelease_types.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/fluxcd/pkg/apis/kustomize"
 	"github.com/fluxcd/pkg/apis/meta"
+
+	v2 "github.com/fluxcd/helm-controller/api/v2"
 )
 
 const (
@@ -976,7 +978,7 @@ type HelmReleaseStatus struct {
 	// History holds the history of Helm releases performed for this HelmRelease
 	// up to the last successfully completed release.
 	// +optional
-	History Snapshots `json:"history,omitempty"`
+	History v2.Snapshots `json:"history,omitempty"`
 
 	// LastAttemptedReleaseAction is the last release action performed for this
 	// HelmRelease. It is used to determine the active remediation strategy.

--- a/api/v2beta2/zz_generated.deepcopy.go
+++ b/api/v2beta2/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v2beta2
 
 import (
+	"github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/pkg/apis/kustomize"
 	"github.com/fluxcd/pkg/apis/meta"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -361,11 +362,11 @@ func (in *HelmReleaseStatus) DeepCopyInto(out *HelmReleaseStatus) {
 	}
 	if in.History != nil {
 		in, out := &in.History, &out.History
-		*out = make(Snapshots, len(*in))
+		*out = make(v2.Snapshots, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {
 				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Snapshot)
+				*out = new(v2.Snapshot)
 				(*in).DeepCopyInto(*out)
 			}
 		}

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -1002,6 +1002,10 @@ spec:
                         Provisional: when the calculation method of the Digest field is changed,
                         this field will be used to distinguish between the old and new methods.
                       type: string
+                    appVersion:
+                      description: Version is the version of the release object in
+                        storage.
+                      type: string
                     chartName:
                       description: ChartName is the chart name of the release object
                         in storage.

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -1003,8 +1003,8 @@ spec:
                         this field will be used to distinguish between the old and new methods.
                       type: string
                     appVersion:
-                      description: Version is the version of the release object in
-                        storage.
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
                       type: string
                     chartName:
                       description: ChartName is the chart name of the release object
@@ -2223,6 +2223,10 @@ spec:
                         APIVersion is the API version of the Snapshot.
                         Provisional: when the calculation method of the Digest field is changed,
                         this field will be used to distinguish between the old and new methods.
+                      type: string
+                    appVersion:
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
                       type: string
                     chartName:
                       description: ChartName is the chart name of the release object
@@ -3508,6 +3512,10 @@ spec:
                         APIVersion is the API version of the Snapshot.
                         Provisional: when the calculation method of the Digest field is changed,
                         this field will be used to distinguish between the old and new methods.
+                      type: string
+                    appVersion:
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
                       type: string
                     chartName:
                       description: ChartName is the chart name of the release object

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -2243,6 +2243,18 @@ int
 </tr>
 <tr>
 <td>
+<code>appVersion</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Version is the version of the release object in storage.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>status</code><br>
 <em>
 string

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -2243,18 +2243,6 @@ int
 </tr>
 <tr>
 <td>
-<code>appVersion</code><br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Version is the version of the release object in storage.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>status</code><br>
 <em>
 string
@@ -2285,6 +2273,18 @@ string
 <td>
 <p>ChartVersion is the chart version of the release object in
 storage.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>appVersion</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AppVersion is the chart app version of the release object in storage.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -1385,7 +1385,7 @@ LAST SEEN   TYPE      REASON             OBJECT                MESSAGE
 88s         Normal    HelmChartInSync    HelmRelease/podinfo   HelmChart/podinfo/podinfo-podinfo with SourceRef 'HelmRepository/podinfo/podinfo' is in-sync
 83s         Normal    InstallSucceeded   HelmRelease/podinfo   Helm install succeeded for release podinfo/podinfo.v1 with chart podinfo@6.5.3
 78s         Warning   TestFailed         HelmRelease/podinfo   Helm test failed for release podinfo/podinfo.v1 with chart podinfo@6.5.3: 1 error occurred:
-            * pod podinfo-fault-test-a0tew failed
+                                                               * pod podinfo-fault-test-a0tew failed
 ```
 
 Besides being reported in Events, the controller may also log reconciliation
@@ -1393,6 +1393,44 @@ errors. The Flux CLI offers commands for filtering the logs for a specific
 HelmRelease, e.g. `flux logs --level=error --kind=HelmRelease --name=<release-name>.`
 
 ## HelmRelease Status
+
+### Events
+
+The controller emits Kubernetes Events to report the result of each Helm action
+performed for a HelmRelease. These events can be used to monitor the progress
+of the HelmRelease and can be forwarded to external systems using 
+[notification-controller alerts](https://fluxcd.io/flux/monitoring/alerts/).
+
+The controller annotates the events with the Helm chart version, app version,
+and with the chart OCI digest if available.
+
+#### Event example
+
+```yaml
+apiVersion: v1
+kind: Event
+metadata:
+  annotations:
+    helm.toolkit.fluxcd.io/app-version: 6.6.1
+    helm.toolkit.fluxcd.io/revision: 6.6.1+0cc9a8446c95
+    helm.toolkit.fluxcd.io/oci-digest: sha256:0cc9a8446c95009ef382f5eade883a67c257f77d50f84e78ecef2aac9428d1e5
+  creationTimestamp: "2024-05-07T05:02:34Z"
+  name: podinfo.17cd1c4e15d474bb
+  namespace: default
+firstTimestamp: "2024-05-07T05:02:34Z"
+involvedObject:
+  apiVersion: helm.toolkit.fluxcd.io/v2
+  kind: HelmRelease
+  name: podinfo
+  namespace: default
+lastTimestamp: "2024-05-07T05:02:34Z"
+message: 'Helm test succeeded for release podinfo/podinfo.v2 with chart podinfo@6.6.1+0cc9a8446c95:
+  3 test hooks completed successfully'
+reason: TestSucceeded
+source:
+  component: helm-controller
+type: Normal
+```
 
 ### History
 
@@ -1414,52 +1452,40 @@ metadata:
   name: <release-name>
 status:
   history:
-    - chartName: podinfo
-      chartVersion: 6.5.3
-      configDigest: sha256:803f06d4673b07668ff270301ca54ca5829da3133c1219f47bd9f52a60b22f9f
-      digest: sha256:3036cf7c06fd35b8ccb15c426fed9ce8a059a0a4befab1a47170b6e962c4d784
-      firstDeployed: '2023-12-06T20:38:47Z'
-      lastDeployed: '2023-12-06T20:52:06Z'
+    - appVersion: 6.6.1
+      chartName: podinfo
+      chartVersion: 6.6.1+0cc9a8446c95
+      configDigest: sha256:e15c415d62760896bd8bec192a44c5716dc224db9e0fc609b9ac14718f8f9e56
+      digest: sha256:e59349a6d8cf01d625de9fe73efd94b5e2a8cc8453d1b893ec367cfa2105bae9
+      firstDeployed: "2024-05-07T04:54:21Z"
+      lastDeployed: "2024-05-07T04:54:55Z"
       name: podinfo
       namespace: podinfo
+      ociDigest: sha256:0cc9a8446c95009ef382f5eade883a67c257f77d50f84e78ecef2aac9428d1e5
       status: deployed
       testHooks:
-        podinfo-grpc-test-qulpw:
-          lastCompleted: '2023-12-06T20:52:09Z'
-          lastStarted: '2023-12-06T20:52:07Z'
-          phase: Succeeded
-        podinfo-jwt-test-xe0ch:
-          lastCompleted: '2023-12-06T20:52:12Z'
-          lastStarted: '2023-12-06T20:52:09Z'
-          phase: Succeeded
-        podinfo-service-test-eh6x2:
-          lastCompleted: '2023-12-06T20:52:14Z'
-          lastStarted: '2023-12-06T20:52:12Z'
-          phase: Succeeded
-      version: 3
-    - chartName: podinfo
-      chartVersion: 6.5.3
-      configDigest: sha256:e15c415d62760896bd8bec192a44c5716dc224db9e0fc609b9ac14718f8f9e56
-      digest: sha256:858b157a63889b25379e287e24a9b38beb09a8ae21f31ae2cf7ad53d70744375
-      firstDeployed: '2023-12-06T20:38:47Z'
-      lastDeployed: '2023-12-06T20:39:02Z'
-      name: podinfo
-      namespace: podinfo
-      status: superseded
-      testHooks:
-        podinfo-grpc-test-aiuee:
-          lastCompleted: '2023-12-06T20:39:04Z'
-          lastStarted: '2023-12-06T20:39:02Z'
-          phase: Succeeded
-        podinfo-jwt-test-dme3b:
-          lastCompleted: '2023-12-06T20:39:07Z'
-          lastStarted: '2023-12-06T20:39:04Z'
-          phase: Succeeded
-        podinfo-service-test-fgvte:
-          lastCompleted: '2023-12-06T20:39:09Z'
-          lastStarted: '2023-12-06T20:39:07Z'
+        podinfo-grpc-test-goyey:
+          lastCompleted: "2024-05-07T04:55:11Z"
+          lastStarted: "2024-05-07T04:55:09Z"
           phase: Succeeded
       version: 2
+    - appVersion: 6.6.0
+      chartName: podinfo
+      chartVersion: 6.6.0+cdd538a0167e
+      configDigest: sha256:e15c415d62760896bd8bec192a44c5716dc224db9e0fc609b9ac14718f8f9e56
+      digest: sha256:9be0d34ced6b890a72026749bc0f1f9e3c1a89673e17921bbcc0f27774f31c3a
+      firstDeployed: "2024-05-07T04:54:21Z"
+      lastDeployed: "2024-05-07T04:54:21Z"
+      name: podinfo
+      namespace: podinfo
+      ociDigest: sha256:cdd538a0167e4b51152b71a477e51eb6737553510ce8797dbcc537e1342311bb
+      status: superseded
+      testHooks:
+        podinfo-grpc-test-q0ucx:
+          lastCompleted: "2024-05-07T04:54:25Z"
+          lastStarted: "2024-05-07T04:54:23Z"
+          phase: Succeeded
+      version: 1
 ```
 
 ### Conditions
@@ -1657,6 +1683,14 @@ to perform a Helm install or upgrade with in the
 
 The revision is used by the controller to determine if it should reset the
 [failure counters](#failure-counters) due to a change in the chart version.
+
+### Last Attempted Revision Digest
+
+The helm-controller reports the OCI artifact digest of the Helm chart it last attempted
+to perform a Helm install or upgrade with in the
+`.status.lastAttemptedRevisionDigest` field.
+
+This field is present in status only when `.spec.chartRef.type` is set to `OCIRepository`.
 
 ### Last Attempted Release Action
 

--- a/internal/reconcile/correct_cluster_drift.go
+++ b/internal/reconcile/correct_cluster_drift.go
@@ -104,10 +104,12 @@ func (r *CorrectClusterDrift) report(obj *v2.HelmRelease, changeSet *ssa.ChangeS
 			sb.WriteString(changeSet.String())
 		}
 
-		r.eventRecorder.AnnotatedEventf(obj, eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)), corev1.EventTypeWarning,
+		r.eventRecorder.AnnotatedEventf(obj, eventMeta(cur.ChartVersion, cur.ConfigDigest,
+			addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)), corev1.EventTypeWarning,
 			"DriftCorrectionFailed", sb.String())
 	case changeSet != nil && len(changeSet.Entries) > 0:
-		r.eventRecorder.AnnotatedEventf(obj, eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)), corev1.EventTypeNormal,
+		r.eventRecorder.AnnotatedEventf(obj, eventMeta(cur.ChartVersion, cur.ConfigDigest,
+			addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)), corev1.EventTypeNormal,
 			"DriftCorrected", "Cluster state of release %s has been corrected:\n%s",
 			obj.Status.History.Latest().FullReleaseName(), changeSet.String())
 	}

--- a/internal/reconcile/install.go
+++ b/internal/reconcile/install.go
@@ -155,7 +155,7 @@ func (r *Install) failure(req *Request, buffer *action.LogBuffer, err error) {
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
 		eventMeta(req.Chart.Metadata.Version, chartutil.DigestValues(digest.Canonical, req.Values).String(),
-			addOCIDigest(req.Object.Status.LastAttemptedRevisionDigest)),
+			addAppVersion(req.Chart.AppVersion()), addOCIDigest(req.Object.Status.LastAttemptedRevisionDigest)),
 		corev1.EventTypeWarning,
 		v2.InstallFailedReason,
 		eventMessageWithLog(msg, buffer),
@@ -182,7 +182,7 @@ func (r *Install) success(req *Request) {
 	// Record event.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeNormal,
 		v2.InstallSucceededReason,
 		msg,

--- a/internal/reconcile/install_test.go
+++ b/internal/reconcile/install_test.go
@@ -342,6 +342,7 @@ func TestInstall_failure(t *testing.T) {
 					Annotations: map[string]string{
 						eventMetaGroupKey(metaOCIDigestKey):        obj.Status.LastAttemptedRevisionDigest,
 						eventMetaGroupKey(eventv1.MetaRevisionKey): chrt.Metadata.Version,
+						eventMetaGroupKey(metaAppVersionKey):       chrt.Metadata.AppVersion,
 						eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, req.Values).String(),
 					},
 				},
@@ -413,6 +414,7 @@ func TestInstall_success(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						eventMetaGroupKey(eventv1.MetaRevisionKey): obj.Status.History.Latest().ChartVersion,
+						eventMetaGroupKey(metaAppVersionKey):       obj.Status.History.Latest().AppVersion,
 						eventMetaGroupKey(eventv1.MetaTokenKey):    obj.Status.History.Latest().ConfigDigest,
 					},
 				},

--- a/internal/reconcile/release.go
+++ b/internal/reconcile/release.go
@@ -200,11 +200,13 @@ func eventMessageWithLog(msg string, log *action.LogBuffer) string {
 // addMeta is a function that adds metadata to an event map.
 type addMeta func(map[string]string)
 
-// metaOCIDigestKey is the key for the OCI digest metadata.
-const metaOCIDigestKey = "oci-digest"
+const (
+	// metaOCIDigestKey is the key for the chart OCI artifact digest.
+	metaOCIDigestKey = "oci-digest"
 
-// metaAppVersionKey is the key for the app version found in chart metadata.
-const metaAppVersionKey = "app-version"
+	// metaAppVersionKey is the key for the app version found in chart metadata.
+	metaAppVersionKey = "app-version"
+)
 
 // eventMeta returns the event (annotation) metadata based on the given
 // parameters.

--- a/internal/reconcile/release.go
+++ b/internal/reconcile/release.go
@@ -203,6 +203,9 @@ type addMeta func(map[string]string)
 // metaOCIDigestKey is the key for the OCI digest metadata.
 const metaOCIDigestKey = "oci-digest"
 
+// metaAppVersionKey is the key for the app version found in chart metadata.
+const metaAppVersionKey = "app-version"
+
 // eventMeta returns the event (annotation) metadata based on the given
 // parameters.
 func eventMeta(revision, token string, metas ...addMeta) map[string]string {
@@ -231,6 +234,17 @@ func addOCIDigest(digest string) addMeta {
 				m = make(map[string]string)
 			}
 			m[eventMetaGroupKey(metaOCIDigestKey)] = digest
+		}
+	}
+}
+
+func addAppVersion(appVersion string) addMeta {
+	return func(m map[string]string) {
+		if appVersion != "" {
+			if m == nil {
+				m = make(map[string]string)
+			}
+			m[eventMetaGroupKey(metaAppVersionKey)] = appVersion
 		}
 	}
 }

--- a/internal/reconcile/rollback_remediation.go
+++ b/internal/reconcile/rollback_remediation.go
@@ -143,7 +143,8 @@ func (r *RollbackRemediation) failure(req *Request, prev *v2.Snapshot, buffer *a
 	// Condition summary.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(prev.ChartVersion, chartutil.DigestValues(digest.Canonical, req.Values).String(), addOCIDigest(prev.OCIDigest)),
+		eventMeta(prev.ChartVersion, chartutil.DigestValues(digest.Canonical, req.Values).String(),
+			addAppVersion(prev.AppVersion), addOCIDigest(prev.OCIDigest)),
 		corev1.EventTypeWarning,
 		v2.RollbackFailedReason,
 		eventMessageWithLog(msg, buffer),
@@ -162,7 +163,8 @@ func (r *RollbackRemediation) success(req *Request, prev *v2.Snapshot) {
 	// Record event.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(prev.ChartVersion, chartutil.DigestValues(digest.Canonical, req.Values).String(), addOCIDigest(prev.OCIDigest)),
+		eventMeta(prev.ChartVersion, chartutil.DigestValues(digest.Canonical, req.Values).String(),
+			addAppVersion(prev.AppVersion), addOCIDigest(prev.OCIDigest)),
 		corev1.EventTypeNormal,
 		v2.RollbackSucceededReason,
 		msg,

--- a/internal/reconcile/rollback_remediation_test.go
+++ b/internal/reconcile/rollback_remediation_test.go
@@ -414,6 +414,7 @@ func TestRollbackRemediation_failure(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						eventMetaGroupKey(eventv1.MetaRevisionKey): prev.Chart.Metadata.Version,
+						eventMetaGroupKey(metaAppVersionKey):       prev.Chart.Metadata.AppVersion,
 						eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, req.Values).String(),
 					},
 				},
@@ -473,6 +474,7 @@ func TestRollbackRemediation_success(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					eventMetaGroupKey(eventv1.MetaRevisionKey): prev.Chart.Metadata.Version,
+					eventMetaGroupKey(metaAppVersionKey):       prev.Chart.Metadata.AppVersion,
 					eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, req.Values).String(),
 				},
 			},

--- a/internal/reconcile/test.go
+++ b/internal/reconcile/test.go
@@ -145,7 +145,7 @@ func (r *Test) failure(req *Request, err error) {
 	// Condition summary.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeWarning,
 		v2.TestFailedReason,
 		msg,
@@ -181,7 +181,7 @@ func (r *Test) success(req *Request) {
 	// Record event.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeNormal,
 		v2.TestSucceededReason,
 		msg,

--- a/internal/reconcile/test_test.go
+++ b/internal/reconcile/test_test.go
@@ -506,6 +506,7 @@ func TestTest_failure(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						eventMetaGroupKey(eventv1.MetaRevisionKey): cur.Chart.Metadata.Version,
+						eventMetaGroupKey(metaAppVersionKey):       cur.Chart.Metadata.AppVersion,
 						eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, cur.Config).String(),
 					},
 				},
@@ -602,6 +603,7 @@ func TestTest_success(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						eventMetaGroupKey(eventv1.MetaRevisionKey): cur.Chart.Metadata.Version,
+						eventMetaGroupKey(metaAppVersionKey):       cur.Chart.Metadata.AppVersion,
 						eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, cur.Config).String(),
 					},
 				},

--- a/internal/reconcile/uninstall.go
+++ b/internal/reconcile/uninstall.go
@@ -180,7 +180,7 @@ func (r *Uninstall) failure(req *Request, buffer *action.LogBuffer, err error) {
 	// Condition summary.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeWarning, v2.UninstallFailedReason,
 		eventMessageWithLog(msg, buffer),
 	)
@@ -201,7 +201,7 @@ func (r *Uninstall) success(req *Request) {
 	// Condition summary.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeNormal,
 		v2.UninstallSucceededReason,
 		msg,

--- a/internal/reconcile/uninstall_remediation.go
+++ b/internal/reconcile/uninstall_remediation.go
@@ -154,7 +154,7 @@ func (r *UninstallRemediation) failure(req *Request, buffer *action.LogBuffer, e
 	// Condition summary.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeWarning,
 		v2.UninstallFailedReason,
 		eventMessageWithLog(msg, buffer),
@@ -175,7 +175,7 @@ func (r *UninstallRemediation) success(req *Request) {
 	// Record event.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeNormal,
 		v2.UninstallSucceededReason,
 		msg,

--- a/internal/reconcile/uninstall_remediation_test.go
+++ b/internal/reconcile/uninstall_remediation_test.go
@@ -421,6 +421,7 @@ func TestUninstallRemediation_failure(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						eventMetaGroupKey(eventv1.MetaRevisionKey): cur.Chart.Metadata.Version,
+						eventMetaGroupKey(metaAppVersionKey):       cur.Chart.Metadata.AppVersion,
 						eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, cur.Config).String(),
 					},
 				},
@@ -490,6 +491,7 @@ func TestUninstallRemediation_success(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					eventMetaGroupKey(eventv1.MetaRevisionKey): cur.Chart.Metadata.Version,
+					eventMetaGroupKey(metaAppVersionKey):       cur.Chart.Metadata.AppVersion,
 					eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, cur.Config).String(),
 				},
 			},

--- a/internal/reconcile/uninstall_test.go
+++ b/internal/reconcile/uninstall_test.go
@@ -549,6 +549,7 @@ func TestUninstall_failure(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						eventMetaGroupKey(eventv1.MetaRevisionKey): cur.Chart.Metadata.Version,
+						eventMetaGroupKey(metaAppVersionKey):       cur.Chart.Metadata.AppVersion,
 						eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, cur.Config).String(),
 					},
 				},
@@ -617,6 +618,7 @@ func TestUninstall_success(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					eventMetaGroupKey(eventv1.MetaRevisionKey): cur.Chart.Metadata.Version,
+					eventMetaGroupKey(metaAppVersionKey):       cur.Chart.Metadata.AppVersion,
 					eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, cur.Config).String(),
 				},
 			},

--- a/internal/reconcile/unlock.go
+++ b/internal/reconcile/unlock.go
@@ -119,7 +119,7 @@ func (r *Unlock) failure(req *Request, cur *v2.Snapshot, status helmrelease.Stat
 	// Record warning event.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeWarning,
 		"PendingRelease",
 		msg,
@@ -138,7 +138,7 @@ func (r *Unlock) success(req *Request, cur *v2.Snapshot, status helmrelease.Stat
 	// Record event.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeNormal,
 		"PendingRelease",
 		msg,

--- a/internal/reconcile/unlock_test.go
+++ b/internal/reconcile/unlock_test.go
@@ -404,6 +404,7 @@ func TestUnlock_failure(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					eventMetaGroupKey(eventv1.MetaRevisionKey): cur.Chart.Metadata.Version,
+					eventMetaGroupKey(metaAppVersionKey):       cur.Chart.Metadata.AppVersion,
 					eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, cur.Config).String(),
 				},
 			},
@@ -450,6 +451,7 @@ func TestUnlock_success(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					eventMetaGroupKey(eventv1.MetaRevisionKey): cur.Chart.Metadata.Version,
+					eventMetaGroupKey(metaAppVersionKey):       cur.Chart.Metadata.AppVersion,
 					eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, cur.Config).String(),
 				},
 			},
@@ -539,6 +541,7 @@ func TestUnlock_withOCIDigest(t *testing.T) {
 				Annotations: map[string]string{
 					eventMetaGroupKey(metaOCIDigestKey):        expected.OCIDigest,
 					eventMetaGroupKey(eventv1.MetaRevisionKey): rls.Chart.Metadata.Version,
+					eventMetaGroupKey(metaAppVersionKey):       rls.Chart.Metadata.AppVersion,
 					eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, rls.Config).String(),
 				},
 			},

--- a/internal/reconcile/upgrade.go
+++ b/internal/reconcile/upgrade.go
@@ -145,7 +145,7 @@ func (r *Upgrade) failure(req *Request, buffer *action.LogBuffer, err error) {
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
 		eventMeta(req.Chart.Metadata.Version, chartutil.DigestValues(digest.Canonical, req.Values).String(),
-			addOCIDigest(req.Object.Status.LastAttemptedRevisionDigest)),
+			addAppVersion(req.Chart.AppVersion()), addOCIDigest(req.Object.Status.LastAttemptedRevisionDigest)),
 		corev1.EventTypeWarning,
 		v2.UpgradeFailedReason,
 		eventMessageWithLog(msg, buffer),
@@ -172,7 +172,7 @@ func (r *Upgrade) success(req *Request) {
 	// Record event.
 	r.eventRecorder.AnnotatedEventf(
 		req.Object,
-		eventMeta(cur.ChartVersion, cur.ConfigDigest, addOCIDigest(cur.OCIDigest)),
+		eventMeta(cur.ChartVersion, cur.ConfigDigest, addAppVersion(cur.AppVersion), addOCIDigest(cur.OCIDigest)),
 		corev1.EventTypeNormal,
 		v2.UpgradeSucceededReason,
 		msg,

--- a/internal/reconcile/upgrade_test.go
+++ b/internal/reconcile/upgrade_test.go
@@ -473,6 +473,7 @@ func TestUpgrade_failure(t *testing.T) {
 					Annotations: map[string]string{
 						eventMetaGroupKey(metaOCIDigestKey):        obj.Status.LastAttemptedRevisionDigest,
 						eventMetaGroupKey(eventv1.MetaRevisionKey): chrt.Metadata.Version,
+						eventMetaGroupKey(metaAppVersionKey):       chrt.Metadata.AppVersion,
 						eventMetaGroupKey(eventv1.MetaTokenKey):    chartutil.DigestValues(digest.Canonical, req.Values).String(),
 					},
 				},
@@ -544,6 +545,7 @@ func TestUpgrade_success(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						eventMetaGroupKey(eventv1.MetaRevisionKey): obj.Status.History.Latest().ChartVersion,
+						eventMetaGroupKey(metaAppVersionKey):       obj.Status.History.Latest().AppVersion,
 						eventMetaGroupKey(eventv1.MetaTokenKey):    obj.Status.History.Latest().ConfigDigest,
 					},
 				},

--- a/internal/release/observation.go
+++ b/internal/release/observation.go
@@ -161,6 +161,7 @@ func ObservedToSnapshot(rls Observation) *v2.Snapshot {
 		Name:          rls.Name,
 		Namespace:     rls.Namespace,
 		Version:       rls.Version,
+		AppVersion:    rls.ChartMetadata.AppVersion,
 		ChartName:     rls.ChartMetadata.Name,
 		ChartVersion:  rls.ChartMetadata.Version,
 		ConfigDigest:  chartutil.DigestValues(digest.Canonical, rls.Config).String(),

--- a/internal/testutil/mock_chart.go
+++ b/internal/testutil/mock_chart.go
@@ -100,6 +100,7 @@ func BuildChart(opts ...ChartOption) *helmchart.Chart {
 				APIVersion: "v1",
 				Name:       "hello",
 				Version:    "0.1.0",
+				AppVersion: "1.2.3",
 			},
 			// This adds a basic template and hooks.
 			Templates: []*helmchart.File{


### PR DESCRIPTION
This PR adds the chart app version to the `.status.history` snapshot and sets the `app-version` annotation to all the issued events. 

This PR makes possible to expose `chart_app_version` as a label on the `gotk_resource_info` metric, ref: https://github.com/fluxcd/flux2-monitoring-example/pull/36