### PR TITLE
PostRenderersDigest observation improvements

### DIFF
--- a/internal/reconcile/release.go
+++ b/internal/reconcile/release.go
@@ -28,8 +28,6 @@ import (
 
 	v2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/helm-controller/internal/action"
-	"github.com/fluxcd/helm-controller/internal/digest"
-	"github.com/fluxcd/helm-controller/internal/postrender"
 	"github.com/fluxcd/helm-controller/internal/release"
 	"github.com/fluxcd/helm-controller/internal/storage"
 )
@@ -190,15 +188,6 @@ func summarize(req *Request) {
 		Message:            conds[0].Message,
 		ObservedGeneration: req.Object.Generation,
 	})
-
-	// remove stale post-renderers digest
-	if conditions.Get(req.Object, meta.ReadyCondition).Status == metav1.ConditionTrue {
-		req.Object.Status.ObservedPostRenderersDigest = ""
-		if req.Object.Spec.PostRenderers != nil {
-			// Update the post-renderers digest if the post-renderers exist.
-			req.Object.Status.ObservedPostRenderersDigest = postrender.Digest(digest.Canonical, req.Object.Spec.PostRenderers).String()
-		}
-	}
 }
 
 // eventMessageWithLog returns an event message composed out of the given

--- a/internal/reconcile/release_test.go
+++ b/internal/reconcile/release_test.go
@@ -31,8 +31,6 @@ import (
 
 	v2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/helm-controller/internal/action"
-	"github.com/fluxcd/helm-controller/internal/digest"
-	"github.com/fluxcd/helm-controller/internal/postrender"
 )
 
 const (
@@ -50,14 +48,14 @@ var (
 							Kind: "Deployment",
 							Name: "test",
 						},
-						Patch: `|-
-						apiVersion: apps/v1
-						kind: Deployment
-						metadata:
-							name: test
-						spec:
-							replicas: 2
-					`,
+						Patch: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  replicas: 2
+`,
 					},
 				},
 			},
@@ -73,14 +71,14 @@ var (
 							Kind: "Deployment",
 							Name: "test",
 						},
-						Patch: `|-
-						apiVersion: apps/v1
-						kind: Deployment
-						metadata:
-							name: test
-						spec:
-							replicas: 3
-					`,
+						Patch: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  replicas: 3
+`,
 					},
 				},
 			},
@@ -507,96 +505,6 @@ func Test_summarize(t *testing.T) {
 						ObservedGeneration: 2,
 					},
 				},
-			},
-		},
-		{
-			name:       "with postrender",
-			generation: 1,
-			status: v2.HelmReleaseStatus{
-				Conditions: []metav1.Condition{
-					{
-						Type:               v2.ReleasedCondition,
-						Status:             metav1.ConditionTrue,
-						Reason:             v2.InstallSucceededReason,
-						Message:            "Install complete",
-						ObservedGeneration: 1,
-					},
-				},
-				ObservedPostRenderersDigest: postrender.Digest(digest.Canonical, postRenderers).String(),
-			},
-			spec: &v2.HelmReleaseSpec{
-				PostRenderers: postRenderers2,
-			},
-			expectedStatus: &v2.HelmReleaseStatus{
-				Conditions: []metav1.Condition{
-					{
-						Type:               meta.ReadyCondition,
-						Status:             metav1.ConditionTrue,
-						Reason:             v2.InstallSucceededReason,
-						Message:            "Install complete",
-						ObservedGeneration: 1,
-					},
-					{
-						Type:               v2.ReleasedCondition,
-						Status:             metav1.ConditionTrue,
-						Reason:             v2.InstallSucceededReason,
-						Message:            "Install complete",
-						ObservedGeneration: 1,
-					},
-				},
-				ObservedPostRenderersDigest: postrender.Digest(digest.Canonical, postRenderers2).String(),
-			},
-		},
-		{
-			name:       "with PostRenderers and Remediaction success",
-			generation: 1,
-			status: v2.HelmReleaseStatus{
-				Conditions: []metav1.Condition{
-					{
-						Type:               v2.ReleasedCondition,
-						Status:             metav1.ConditionFalse,
-						Reason:             v2.UpgradeFailedReason,
-						Message:            "Upgrade failure",
-						ObservedGeneration: 1,
-					},
-					{
-						Type:               v2.RemediatedCondition,
-						Status:             metav1.ConditionTrue,
-						Reason:             v2.RollbackSucceededReason,
-						Message:            "Uninstall complete",
-						ObservedGeneration: 1,
-					},
-				},
-				ObservedPostRenderersDigest: postrender.Digest(digest.Canonical, postRenderers).String(),
-			},
-			spec: &v2.HelmReleaseSpec{
-				PostRenderers: postRenderers2,
-			},
-			expectedStatus: &v2.HelmReleaseStatus{
-				Conditions: []metav1.Condition{
-					{
-						Type:               meta.ReadyCondition,
-						Status:             metav1.ConditionFalse,
-						Reason:             v2.RollbackSucceededReason,
-						Message:            "Uninstall complete",
-						ObservedGeneration: 1,
-					},
-					{
-						Type:               v2.ReleasedCondition,
-						Status:             metav1.ConditionFalse,
-						Reason:             v2.UpgradeFailedReason,
-						Message:            "Upgrade failure",
-						ObservedGeneration: 1,
-					},
-					{
-						Type:               v2.RemediatedCondition,
-						Status:             metav1.ConditionTrue,
-						Reason:             v2.RollbackSucceededReason,
-						Message:            "Uninstall complete",
-						ObservedGeneration: 1,
-					},
-				},
-				ObservedPostRenderersDigest: postrender.Digest(digest.Canonical, postRenderers).String(),
 			},
 		},
 	}

--- a/internal/reconcile/state_test.go
+++ b/internal/reconcile/state_test.go
@@ -27,8 +27,10 @@ import (
 	helmrelease "helm.sh/helm/v3/pkg/release"
 	helmstorage "helm.sh/helm/v3/pkg/storage"
 	helmdriver "helm.sh/helm/v3/pkg/storage/driver"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/ssa/jsondiff"
 	ssanormalize "github.com/fluxcd/pkg/ssa/normalize"
 	ssautil "github.com/fluxcd/pkg/ssa/utils"
@@ -474,12 +476,54 @@ func Test_DetermineReleaseState(t *testing.T) {
 						release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 					},
 					ObservedPostRenderersDigest: postrender.Digest(digest.Canonical, postRenderers).String(),
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1,
+						},
+					},
 				}
 			},
 			chart:  testutil.BuildChart(),
 			values: map[string]interface{}{"foo": "bar"},
 			want: ReleaseState{
 				Status: ReleaseStatusOutOfSync,
+			},
+		},
+		{
+			name: "postRenderers mismatch ignored for processed generation",
+			releases: []*helmrelease.Release{
+				testutil.BuildRelease(&helmrelease.MockReleaseOptions{
+					Name:      mockReleaseName,
+					Namespace: mockReleaseNamespace,
+					Version:   1,
+					Status:    helmrelease.StatusDeployed,
+					Chart:     testutil.BuildChart(),
+				}, testutil.ReleaseWithConfig(map[string]interface{}{"foo": "bar"})),
+			},
+			spec: func(spec *v2.HelmReleaseSpec) {
+				spec.PostRenderers = postRenderers2
+			},
+			status: func(releases []*helmrelease.Release) v2.HelmReleaseStatus {
+				return v2.HelmReleaseStatus{
+					History: v2.Snapshots{
+						release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					},
+					ObservedPostRenderersDigest: postrender.Digest(digest.Canonical, postRenderers).String(),
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 2,
+						},
+					},
+				}
+			},
+			chart:  testutil.BuildChart(),
+			values: map[string]interface{}{"foo": "bar"},
+			want: ReleaseState{
+				Status: ReleaseStatusInSync,
 			},
 		},
 	}
@@ -495,6 +539,10 @@ func Test_DetermineReleaseState(t *testing.T) {
 					StorageNamespace: mockReleaseNamespace,
 				},
 			}
+			// Set a non-zero generation so that old observations can be set on
+			// the object status.
+			obj.Generation = 2
+
 			if tt.spec != nil {
 				tt.spec(&obj.Spec)
 			}


### PR DESCRIPTION
This adds a minor improvement to the implementation of the observing the post renderers digest in #965 by moving the observation set/update code from `summarize()` to atomic release reconciliation. `summarize()` is for summarizing the status conditions only and it is called by all the action sub-reconcilers. In addition, the post renderers digest value check is performed only for unprocessed new configuration. This is needed to prevent the atomic reconciliation from getting stuck in a loop when there are multiple upgrades, for example due to a config difference and a digest mismatch, and since the digest gets updated at the very end of a successful reconciliation, the release can get stuck. This make sure that the digest is checked only for unprocessed generation of the object. This behavior is only associated with the changes introduced here. Previously, the observation got updated early within the `summarize()` which got around such issue.

Also, adds more tests for various scenarios involving post renderers.