### PR TITLE
Prevent snapshot drift when upgrading to API v2

### DIFF
--- a/internal/release/digest_test.go
+++ b/internal/release/digest_test.go
@@ -37,7 +37,7 @@ func TestDigest(t *testing.T) {
 			rel: Observation{
 				Name: "foo",
 			},
-			exp: "sha256:ca8901e499a79368647134cc4f1c2118f8e7ec64c8a4703b281d17fb01acfbed",
+			exp: "sha256:91b6773f7696d3eb405708a07e2daedc6e69664dabac8e10af7d570d09f947d5",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/release/observation.go
+++ b/internal/release/observation.go
@@ -80,7 +80,7 @@ type Observation struct {
 	// Namespace is the Kubernetes namespace of the release.
 	Namespace string `json:"namespace"`
 	// OCIDigest is the digest of the OCI artifact that was used to
-	OCIDigest string `json:"ociDigest"`
+	OCIDigest string `json:"ociDigest,omitempty"`
 }
 
 // Targets returns if the release matches the given name, namespace and


### PR DESCRIPTION
Mark `Observation.OCIDigest` as `omitempty` to avoid a snapshot drift when upgrading to API v2.

Before this fix, when updating the controller & CRDs from v0.x to v1.0 all releases were upgraded due to:
```
release not managed by controller: release not observed to be made for object
```

Whit this fix, the history snapshot remains unchanged, as the OCI digest empty string is no longer included in the calculation of the config digest.

Followup: https://github.com/fluxcd/helm-controller/pull/905