### PR TITLE
doc: fix HelmRelease default value for `.spec.upgrade.crds`

### DIFF
--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -524,7 +524,7 @@ The field offers the following subfields:
   operation (like Jobs for hooks) during the upgrade of the release.
   Defaults to the [global timeout value](#timeout).
 - `.crds` (Optional): The Custom Resource Definition upgrade policy to use.
-  Valid values are `Skip`, `Create` and `CreateReplace`. Default is `None`.
+  Valid values are `Skip`, `Create` and `CreateReplace`. Default is `Skip`.
   Refer to [Custom Resource Definition lifecycle](#controlling-the-lifecycle-of-custom-resource-definitions)
   for more information.
 - `.cleanupOnFail` (Optional): Allows deletion of new resources created during

--- a/docs/spec/v2beta2/helmreleases.md
+++ b/docs/spec/v2beta2/helmreleases.md
@@ -520,7 +520,7 @@ The field offers the following subfields:
   operation (like Jobs for hooks) during the upgrade of the release.
   Defaults to the [global timeout value](#timeout).
 - `.crds` (Optional): The Custom Resource Definition upgrade policy to use.
-  Valid values are `Skip`, `Create` and `CreateReplace`. Default is `None`.
+  Valid values are `Skip`, `Create` and `CreateReplace`. Default is `Skip`.
   Refer to [Custom Resource Definition lifecycle](#controlling-the-lifecycle-of-custom-resource-definitions)
   for more information.
 - `.cleanupOnFail` (Optional): Allows deletion of new resources created during


### PR DESCRIPTION
In the HelmRelease documentation, the default value for `.spec.upgrade.crds` is set as `None` in [Upgrade configuration](https://fluxcd.io/flux/components/helm/helmreleases/#upgrade-configuration) part, then the default value is set as `Skip` in [Controlling the lifecycle of Custom Resource Definitions](https://fluxcd.io/flux/components/helm/helmreleases/#controlling-the-lifecycle-of-custom-resource-definitions) part.