### PR TITLE
Ignore 'v' version prefix in OCI artifact and Helm chart

### DIFF
--- a/internal/controller/helmrelease_controller.go
+++ b/internal/controller/helmrelease_controller.go
@@ -915,7 +915,11 @@ func mutateChartWithSourceRevision(chart *chart.Chart, source sourcev1.Source) (
 	switch {
 	case strings.Contains(revision, "@"):
 		tagD := strings.Split(revision, "@")
-		if len(tagD) != 2 || tagD[0] != chart.Metadata.Version {
+		tagVer, err := semver.NewVersion(tagD[0])
+		if err != nil {
+			return "", fmt.Errorf("failed parsing artifact revision %s", tagD[0])
+		}
+		if len(tagD) != 2 || !tagVer.Equal(ver) {
 			return "", fmt.Errorf("artifact revision %s does not match chart version %s", tagD[0], chart.Metadata.Version)
 		}
 		// algotithm are sha256, sha384, sha512 with the canonical being sha256


### PR DESCRIPTION
Tools such as Bitnami's charts-syncer strip the `v` prefix from the chart version so that the OCI artifact version differs from the version defined in the chart's metadata. This leads to an error similar to this returned from h-c:

```
artifact revision 1.14.5 does not match chart version v1.14.5
```

This PR makes h-c ignore a leading `v` prefix in either the chart version of the OCI artifact tag.