### PR TITLE
Move 'Deprecated' comments to own paragraph

### DIFF
--- a/api/v2/helmrelease_types.go
+++ b/api/v2/helmrelease_types.go
@@ -1045,11 +1045,13 @@ type HelmReleaseStatus struct {
 
 	// LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
 	// reconciliation attempt.
+	//
 	// Deprecated: Use LastAttemptedConfigDigest instead.
 	// +optional
 	LastAttemptedValuesChecksum string `json:"lastAttemptedValuesChecksum,omitempty"`
 
 	// LastReleaseRevision is the revision of the last successful Helm release.
+	//
 	// Deprecated: Use History instead.
 	// +optional
 	LastReleaseRevision int `json:"lastReleaseRevision,omitempty"`

--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -1205,6 +1205,7 @@ func (in *HelmRelease) SetConditions(conditions []metav1.Condition) {
 }
 
 // GetStatusConditions returns a pointer to the Status.Conditions slice.
+//
 // Deprecated: use GetConditions instead.
 func (in *HelmRelease) GetStatusConditions() *[]metav1.Condition {
 	return &in.Status.Conditions

--- a/api/v2beta2/helmrelease_types.go
+++ b/api/v2beta2/helmrelease_types.go
@@ -52,11 +52,13 @@ type Kustomize struct {
 	Patches []kustomize.Patch `json:"patches,omitempty"`
 
 	// Strategic merge patches, defined as inline YAML objects.
+	//
 	// Deprecated: use Patches instead.
 	// +optional
 	PatchesStrategicMerge []apiextensionsv1.JSON `json:"patchesStrategicMerge,omitempty"`
 
 	// JSON 6902 patches, defined as inline YAML objects.
+	//
 	// Deprecated: use Patches instead.
 	// +optional
 	PatchesJSON6902 []kustomize.JSON6902Patch `json:"patchesJson6902,omitempty"`
@@ -1011,6 +1013,7 @@ type HelmReleaseStatus struct {
 
 	// LastAppliedRevision is the revision of the last successfully applied
 	// source.
+	//
 	// Deprecated: the revision can now be found in the History.
 	// +optional
 	LastAppliedRevision string `json:"lastAppliedRevision,omitempty"`
@@ -1028,11 +1031,13 @@ type HelmReleaseStatus struct {
 
 	// LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
 	// reconciliation attempt.
+	//
 	// Deprecated: Use LastAttemptedConfigDigest instead.
 	// +optional
 	LastAttemptedValuesChecksum string `json:"lastAttemptedValuesChecksum,omitempty"`
 
 	// LastReleaseRevision is the revision of the last successful Helm release.
+	//
 	// Deprecated: Use History instead.
 	// +optional
 	LastReleaseRevision int `json:"lastReleaseRevision,omitempty"`
@@ -1266,6 +1271,7 @@ func (in *HelmRelease) SetConditions(conditions []metav1.Condition) {
 }
 
 // GetStatusConditions returns a pointer to the Status.Conditions slice.
+//
 // Deprecated: use GetConditions instead.
 func (in *HelmRelease) GetStatusConditions() *[]metav1.Condition {
 	return &in.Status.Conditions

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -1147,6 +1147,7 @@ spec:
                 description: |-
                   LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
                   reconciliation attempt.
+
                   Deprecated: Use LastAttemptedConfigDigest instead.
                 type: string
               lastHandledForceAt:
@@ -1169,6 +1170,7 @@ spec:
               lastReleaseRevision:
                 description: |-
                   LastReleaseRevision is the revision of the last successful Helm release.
+
                   Deprecated: Use History instead.
                 type: integer
               observedCommonMetadataDigest:
@@ -3021,6 +3023,7 @@ spec:
                         patchesJson6902:
                           description: |-
                             JSON 6902 patches, defined as inline YAML objects.
+
                             Deprecated: use Patches instead.
                           items:
                             description: JSON6902Patch contains a JSON6902 patch and
@@ -3117,6 +3120,7 @@ spec:
                         patchesStrategicMerge:
                           description: |-
                             Strategic merge patches, defined as inline YAML objects.
+
                             Deprecated: use Patches instead.
                           items:
                             x-kubernetes-preserve-unknown-fields: true
@@ -3626,6 +3630,7 @@ spec:
                 description: |-
                   LastAppliedRevision is the revision of the last successfully applied
                   source.
+
                   Deprecated: the revision can now be found in the History.
                 type: string
               lastAttemptedConfigDigest:
@@ -3662,6 +3667,7 @@ spec:
                 description: |-
                   LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
                   reconciliation attempt.
+
                   Deprecated: Use LastAttemptedConfigDigest instead.
                 type: string
               lastHandledForceAt:
@@ -3683,6 +3689,7 @@ spec:
               lastReleaseRevision:
                 description: |-
                   LastReleaseRevision is the revision of the last successful Helm release.
+
                   Deprecated: Use History instead.
                 type: integer
               observedGeneration:

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -1694,8 +1694,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
-reconciliation attempt.
-Deprecated: Use LastAttemptedConfigDigest instead.</p>
+reconciliation attempt.</p>
+<p>Deprecated: Use LastAttemptedConfigDigest instead.</p>
 </td>
 </tr>
 <tr>
@@ -1707,8 +1707,8 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastReleaseRevision is the revision of the last successful Helm release.
-Deprecated: Use History instead.</p>
+<p>LastReleaseRevision is the revision of the last successful Helm release.</p>
+<p>Deprecated: Use History instead.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
As described at https://go.dev/wiki/Deprecated, the `Deprecated` comments shall start a new paragraph. This way, the deprecation is also visible to other tools like staticcheck or vscode. Otherwise, one might get surprised by the removal of deprecated fields.
I also ran `make manifests`, which adds some newlines.