### PR TITLE
Re-enable logging json patch on StatusDrifted

### DIFF
--- a/internal/reconcile/atomic_release.go
+++ b/internal/reconcile/atomic_release.go
@@ -388,8 +388,13 @@ func (r *AtomicRelease) actionForState(ctx context.Context, req *Request, state 
 				log.V(logger.DebugLevel).Info("resource deleted",
 					"resource", diff.ResourceName(change.DesiredObject))
 			case jsondiff.DiffTypeUpdate:
+				patch := change.Patch
+				if change.DesiredObject.GetObjectKind().GroupVersionKind().Kind == "Secret" {
+					patch = jsondiff.MaskSecretPatchData(change.Patch)
+				}
 				log.V(logger.DebugLevel).Info("resource modified",
-					"resource", diff.ResourceName(change.DesiredObject))
+					"resource", diff.ResourceName(change.DesiredObject),
+					"patch", patch)
 			}
 		}
 


### PR DESCRIPTION
fix #1008 

We previously disabled logging json patches on `ReleaseStatusDrifted` due to the fact that the `MaskSecretPatchData()` cannot differentiate between `Secrets` and `ConfigMaps` in #935

We are re-enabling this with a check on the `kind` to know when to call `MaskSecretPatchData()`.