### PR TITLE
Allow overwriting inline values with targetPath

### DIFF
--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -413,7 +413,8 @@ Changes to the combined values will trigger a new Helm release.
 `.spec.valuesFrom` is an optional list to refer to ConfigMap and Secret
 resources from which to take values. The values are merged in the order given,
 with the later values overwriting earlier, and then [inline values](#inline-values)
-overwriting those.
+overwriting those. When `targetPath` is set, it will overwrite everything before,
+including inline values.
 
 An item on the list offers the following subkeys:
 

--- a/docs/spec/v2beta2/helmreleases.md
+++ b/docs/spec/v2beta2/helmreleases.md
@@ -409,7 +409,8 @@ Changes to the combined values will trigger a new Helm release.
 `.spec.valuesFrom` is an optional list to refer to ConfigMap and Secret
 resources from which to take values. The values are merged in the order given,
 with the later values overwriting earlier, and then [inline values](#inline-values)
-overwriting those.
+overwriting those. When `targetPath` is set, it will overwrite everything before,
+including inline values.
 
 An item on the list offers the following subkeys:
 

--- a/internal/chartutil/values.go
+++ b/internal/chartutil/values.go
@@ -149,8 +149,9 @@ const (
 
 // ChartValuesFromReferences attempts to construct new chart values by resolving
 // the provided references using the client, merging them in the order given.
-// If provided, the values map is merged in last. Overwriting values from
-// references. It returns the merged values, or an ErrValuesReference error.
+// If provided, the values map is merged in last overwriting values from references,
+// unless a reference has a targetPath specified, in which case it will overwrite all.
+// It returns the merged values, or an ErrValuesReference error.
 func ChartValuesFromReferences(ctx context.Context, client kubeclient.Client, namespace string,
 	values map[string]interface{}, refs ...v2.ValuesReference) (chartutil.Values, error) {
 
@@ -234,6 +235,8 @@ func ChartValuesFromReferences(ctx context.Context, client kubeclient.Client, na
 		}
 
 		if ref.TargetPath != "" {
+			result = transform.MergeMaps(result, values)
+
 			// TODO(hidde): this is a bit of hack, as it mimics the way the option string is passed
 			// 	to Helm from a CLI perspective. Given the parser is however not publicly accessible
 			// 	while it contains all logic around parsing the target path, it is a fair trade-off.

--- a/internal/chartutil/values_test.go
+++ b/internal/chartutil/values_test.go
@@ -104,6 +104,47 @@ other: values
 			},
 		},
 		{
+			name: "target path precedence over all",
+			resources: []runtime.Object{
+				mockConfigMap("values", map[string]string{
+					"values.yaml": `flat: value
+nested:
+  configuration:
+  - one
+  - two
+  - three
+`,
+				}),
+				mockSecret("values", map[string][]byte{"key": []byte("value")}),
+			},
+			references: []v2.ValuesReference{
+				{
+					Kind:       kindSecret,
+					Name:       "values",
+					ValuesKey:  "key",
+					TargetPath: "nested.configuration[0]",
+				},
+				{
+					Kind: kindConfigMap,
+					Name: "values",
+				},
+			},
+
+			values: `
+nested:
+  configuration:
+  - list
+  - item
+  - option
+`,
+			want: chartutil.Values{
+				"flat": "value",
+				"nested": map[string]interface{}{
+					"configuration": []interface{}{"value", "item", "option"},
+				},
+			},
+		},
+		{
 			name: "target path for string type array item",
 			resources: []runtime.Object{
 				mockConfigMap("values", map[string]string{


### PR DESCRIPTION
Fix: https://github.com/fluxcd/flux2/issues/2330

When using Helm with both a values file and --set, the set will always have precedence over the values.yaml. This allows specifying the normal config inside a yaml file and specifying a secret outside that yaml via --set.

When using flux, this normally works too (using inline values to specify most of the config and a reference with targetPath to get a secret), but if you want to overwrite a secret key inside an array the inline values will always overwrite the whole array and the referenced secret key will not appear at all.

By making sure that when you specify a targetPath it has precedence over inline values it will be merged properly.

The Workaround mentioned in the original issue is limiting, because you can not easily use kustomize to overwrite certain keys in a configmap values.yaml stringBlock (for example in a multicluster setup with a common base), but you can do it with inline values.