### PR TITLE
Add `disableSchemaValidation` to Helm install/upgrade actions

### DIFF
--- a/api/v2/helmrelease_types.go
+++ b/api/v2/helmrelease_types.go
@@ -451,6 +451,11 @@ type Install struct {
 	// +optional
 	DisableOpenAPIValidation bool `json:"disableOpenAPIValidation,omitempty"`
 
+	// DisableSchemaValidation prevents the Helm install action from validating
+	// the values against the JSON Schema.
+	// +optional
+	DisableSchemaValidation bool `json:"disableSchemaValidation,omitempty"`
+
 	// Replace tells the Helm install action to re-use the 'ReleaseName', but only
 	// if that name is a deleted release which remains in the history.
 	// +optional
@@ -623,6 +628,11 @@ type Upgrade struct {
 	// rendered templates against the Kubernetes OpenAPI Schema.
 	// +optional
 	DisableOpenAPIValidation bool `json:"disableOpenAPIValidation,omitempty"`
+
+	// DisableSchemaValidation prevents the Helm upgrade action from validating
+	// the values against the JSON Schema.
+	// +optional
+	DisableSchemaValidation bool `json:"disableSchemaValidation,omitempty"`
 
 	// Force forces resource updates through a replacement strategy.
 	// +optional

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -365,6 +365,11 @@ spec:
                       DisableOpenAPIValidation prevents the Helm install action from validating
                       rendered templates against the Kubernetes OpenAPI Schema.
                     type: boolean
+                  disableSchemaValidation:
+                    description: |-
+                      DisableSchemaValidation prevents the Helm install action from validating
+                      the values against the JSON Schema.
+                    type: boolean
                   disableWait:
                     description: |-
                       DisableWait disables the waiting for resources to be ready after a Helm
@@ -773,6 +778,11 @@ spec:
                     description: |-
                       DisableOpenAPIValidation prevents the Helm upgrade action from validating
                       rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableSchemaValidation:
+                    description: |-
+                      DisableSchemaValidation prevents the Helm upgrade action from validating
+                      the values against the JSON Schema.
                     type: boolean
                   disableWait:
                     description: |-

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -1832,6 +1832,19 @@ rendered templates against the Kubernetes OpenAPI Schema.</p>
 </tr>
 <tr>
 <td>
+<code>disableSchemaValidation</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableSchemaValidation prevents the Helm install action from validating
+the values against the JSON Schema.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>replace</code><br>
 <em>
 bool
@@ -2716,6 +2729,19 @@ bool
 <em>(Optional)</em>
 <p>DisableOpenAPIValidation prevents the Helm upgrade action from validating
 rendered templates against the Kubernetes OpenAPI Schema.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>disableSchemaValidation</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableSchemaValidation prevents the Helm upgrade action from validating
+the values against the JSON Schema.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -492,6 +492,8 @@ The field offers the following subfields:
   from running during the installation of the chart. Defaults to `false`.
 - `.disableOpenAPIValidation` (Optional): Prevents Helm from validating the
   rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`.
+- `.disableSchemaValidation` (Optional): Prevents Helm from validating the
+  values against the JSON Schema. Defaults to `false`.
 - `.disableWait` (Optional): Disables waiting for resources to be ready after
   the installation of the chart. Defaults to `false`.
 - `.disableWaitForJobs` (Optional): Disables waiting for any Jobs to complete
@@ -534,6 +536,8 @@ The field offers the following subfields:
   from running during the upgrade of the release. Defaults to `false`.
 - `.disableOpenAPIValidation` (Optional): Prevents Helm from validating the
   rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`.
+- `.disableSchemaValidation` (Optional): Prevents Helm from validating the
+  values against the JSON Schema. Defaults to `false`.
 - `.disableWait` (Optional): Disables waiting for resources to be ready after
   upgrading the release. Defaults to `false`.
 - `.disableWaitForJobs` (Optional): Disables waiting for any Jobs to complete

--- a/internal/action/install.go
+++ b/internal/action/install.go
@@ -72,6 +72,7 @@ func newInstall(config *helmaction.Configuration, obj *v2.HelmRelease, opts []In
 	install.WaitForJobs = !obj.GetInstall().DisableWaitForJobs
 	install.DisableHooks = obj.GetInstall().DisableHooks
 	install.DisableOpenAPIValidation = obj.GetInstall().DisableOpenAPIValidation
+	install.SkipSchemaValidation = obj.GetInstall().DisableSchemaValidation
 	install.Replace = obj.GetInstall().Replace
 	install.Devel = true
 	install.SkipCRDs = true

--- a/internal/action/upgrade.go
+++ b/internal/action/upgrade.go
@@ -73,6 +73,7 @@ func newUpgrade(config *helmaction.Configuration, obj *v2.HelmRelease, opts []Up
 	upgrade.WaitForJobs = !obj.GetUpgrade().DisableWaitForJobs
 	upgrade.DisableHooks = obj.GetUpgrade().DisableHooks
 	upgrade.DisableOpenAPIValidation = obj.GetUpgrade().DisableOpenAPIValidation
+	upgrade.SkipSchemaValidation = obj.GetUpgrade().DisableSchemaValidation
 	upgrade.Force = obj.GetUpgrade().Force
 	upgrade.CleanupOnFail = obj.GetUpgrade().CleanupOnFail
 	upgrade.Devel = true


### PR DESCRIPTION
This PR adds a new field called `disableSchemaValidation` to both `.spec.install` and `.spec.upgrade` that allows disabling the values validation against the JSON schema during install and upgrade. 

Closes: https://github.com/fluxcd/flux2/issues/4992

xref: https://github.com/helm/helm/pull/12743