### PR TITLE
Label sync for release/v1.1.x

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -16,3 +16,6 @@
 - name: backport:release/v1.0.x
   description: To be backported to release/v1.0.x
   color: '#ffd700'
+- name: backport:release/v1.1.x
+  description: To be backported to release/v1.1.x
+  color: '#ffd700'


### PR DESCRIPTION
:warning:  Merge after https://github.com/fluxcd/helm-controller/pull/1075 since branch `release/v1.1.x` is write protected and can't be rebased.