### PR TITLE
fix: Add back the helm suspended metric

### DIFF
--- a/internal/controller/helmrelease_controller.go
+++ b/internal/controller/helmrelease_controller.go
@@ -205,8 +205,9 @@ func (r *HelmReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			log.Error(err, "failed to wait for object to sync in-cache after patching")
 		}
 
-		// Record the duration of the reconciliation.
+		// Record Prometheus metrics.
 		r.Metrics.RecordDuration(ctx, obj, start)
+		r.Metrics.RecordSuspend(ctx, obj, obj.Spec.Suspend)
 	}()
 
 	// Examine if the object is under deletion.


### PR DESCRIPTION
At some point we had this and then we lost it. Discovered after we started suspending a bunch of things but could not get this metric to appear, meaning we are currently in a quasi-state of releases suspended across all our clusters that we don't know about.