### PR TITLE
Add `disableTakeOwnership` to Helm install/upgrade actions

### DIFF
--- a/api/v2/helmrelease_types.go
+++ b/api/v2/helmrelease_types.go
@@ -435,6 +435,11 @@ type Install struct {
 	// +optional
 	Remediation *InstallRemediation `json:"remediation,omitempty"`
 
+	// DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
+	// ownership of the existing resources during the Helm install action. Defaults to false.
+	// +optional
+	DisableTakeOwnership bool `json:"disableTakeOwnership,omitempty"`
+
 	// DisableWait disables the waiting for resources to be ready after a Helm
 	// install has been performed.
 	// +optional
@@ -612,6 +617,11 @@ type Upgrade struct {
 	// action for the HelmRelease fails. The default is to not perform any action.
 	// +optional
 	Remediation *UpgradeRemediation `json:"remediation,omitempty"`
+
+	// DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
+	// ownership of the existing resources during the Helm upgrade action. Defaults to false.
+	// +optional
+	DisableTakeOwnership bool `json:"disableTakeOwnership,omitempty"`
 
 	// DisableWait disables the waiting for resources to be ready after a Helm
 	// upgrade has been performed.

--- a/api/v2/helmrelease_types.go
+++ b/api/v2/helmrelease_types.go
@@ -435,8 +435,8 @@ type Install struct {
 	// +optional
 	Remediation *InstallRemediation `json:"remediation,omitempty"`
 
-	// DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
-	// ownership of the existing resources during the Helm install action. Defaults to false.
+	// DisableTakeOwnership disables taking ownership of existing resources
+	// during the Helm install action. Defaults to false.
 	// +optional
 	DisableTakeOwnership bool `json:"disableTakeOwnership,omitempty"`
 
@@ -618,8 +618,8 @@ type Upgrade struct {
 	// +optional
 	Remediation *UpgradeRemediation `json:"remediation,omitempty"`
 
-	// DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
-	// ownership of the existing resources during the Helm upgrade action. Defaults to false.
+	// DisableTakeOwnership disables taking ownership of existing resources
+	// during the Helm upgrade action. Defaults to false.
 	// +optional
 	DisableTakeOwnership bool `json:"disableTakeOwnership,omitempty"`
 

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -370,6 +370,11 @@ spec:
                       DisableSchemaValidation prevents the Helm install action from validating
                       the values against the JSON Schema.
                     type: boolean
+                  disableTakeOwnership:
+                    description: |-
+                      DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
+                      ownership of the existing resources during the Helm install action. Defaults to false.
+                    type: boolean
                   disableWait:
                     description: |-
                       DisableWait disables the waiting for resources to be ready after a Helm
@@ -783,6 +788,11 @@ spec:
                     description: |-
                       DisableSchemaValidation prevents the Helm upgrade action from validating
                       the values against the JSON Schema.
+                    type: boolean
+                  disableTakeOwnership:
+                    description: |-
+                      DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
+                      ownership of the existing resources during the Helm upgrade action. Defaults to false.
                     type: boolean
                   disableWait:
                     description: |-

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -372,8 +372,8 @@ spec:
                     type: boolean
                   disableTakeOwnership:
                     description: |-
-                      DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
-                      ownership of the existing resources during the Helm install action. Defaults to false.
+                      DisableTakeOwnership disables taking ownership of existing resources
+                      during the Helm install action. Defaults to false.
                     type: boolean
                   disableWait:
                     description: |-
@@ -791,8 +791,8 @@ spec:
                     type: boolean
                   disableTakeOwnership:
                     description: |-
-                      DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
-                      ownership of the existing resources during the Helm upgrade action. Defaults to false.
+                      DisableTakeOwnership disables taking ownership of existing resources
+                      during the Helm upgrade action. Defaults to false.
                     type: boolean
                   disableWait:
                     description: |-

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -1781,6 +1781,19 @@ action for the HelmRelease fails. The default is to not perform any action.</p>
 </tr>
 <tr>
 <td>
+<code>disableTakeOwnership</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
+ownership of the existing resources during the Helm install action. Defaults to false.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>disableWait</code><br>
 <em>
 bool
@@ -2678,6 +2691,19 @@ UpgradeRemediation
 <em>(Optional)</em>
 <p>Remediation holds the remediation configuration for when the Helm upgrade
 action for the HelmRelease fails. The default is to not perform any action.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>disableTakeOwnership</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
+ownership of the existing resources during the Helm upgrade action. Defaults to false.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -1788,8 +1788,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
-ownership of the existing resources during the Helm install action. Defaults to false.</p>
+<p>DisableTakeOwnership disables taking ownership of existing resources
+during the Helm install action. Defaults to false.</p>
 </td>
 </tr>
 <tr>
@@ -2702,8 +2702,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>DisableTakeOwnership disables ignoring the check for helm labels and annotations before taking
-ownership of the existing resources during the Helm upgrade action. Defaults to false.</p>
+<p>DisableTakeOwnership disables taking ownership of existing resources
+during the Helm upgrade action. Defaults to false.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -495,7 +495,7 @@ The field offers the following subfields:
 - `.disableSchemaValidation` (Optional): Prevents Helm from validating the
   values against the JSON Schema. Defaults to `false`.
 - `.disableTakeOwnership` (Optional): Disables ignoring the check for helm labels and annotations before taking
-  ownership of the existing resources during the Helm install action. Defaults to `false`.
+  ownership of the existing resources during the Helm upgrade action. Defaults to `false`.
 - `.disableWait` (Optional): Disables waiting for resources to be ready after
   the installation of the chart. Defaults to `false`.
 - `.disableWaitForJobs` (Optional): Disables waiting for any Jobs to complete

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -494,6 +494,8 @@ The field offers the following subfields:
   rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`.
 - `.disableSchemaValidation` (Optional): Prevents Helm from validating the
   values against the JSON Schema. Defaults to `false`.
+- `.disableTakeOwnership` (Optional): Disables ignoring the check for helm labels and annotations before taking
+  ownership of the existing resources during the Helm install action. Defaults to `false`.
 - `.disableWait` (Optional): Disables waiting for resources to be ready after
   the installation of the chart. Defaults to `false`.
 - `.disableWaitForJobs` (Optional): Disables waiting for any Jobs to complete
@@ -538,6 +540,8 @@ The field offers the following subfields:
   rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`.
 - `.disableSchemaValidation` (Optional): Prevents Helm from validating the
   values against the JSON Schema. Defaults to `false`.
+- `.disableTakeOwnership` (Optional): Disables ignoring the check for helm labels and annotations before taking
+  ownership of the existing resources during the Helm install action. Defaults to `false`.
 - `.disableWait` (Optional): Disables waiting for resources to be ready after
   upgrading the release. Defaults to `false`.
 - `.disableWaitForJobs` (Optional): Disables waiting for any Jobs to complete

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -495,7 +495,7 @@ The field offers the following subfields:
 - `.disableSchemaValidation` (Optional): Prevents Helm from validating the
   values against the JSON Schema. Defaults to `false`.
 - `.disableTakeOwnership` (Optional): Disables ignoring the check for helm labels and annotations before taking
-  ownership of the existing resources during the Helm upgrade action. Defaults to `false`.
+  ownership of the existing resources during the Helm install action. Defaults to `false`.
 - `.disableWait` (Optional): Disables waiting for resources to be ready after
   the installation of the chart. Defaults to `false`.
 - `.disableWaitForJobs` (Optional): Disables waiting for any Jobs to complete
@@ -541,7 +541,7 @@ The field offers the following subfields:
 - `.disableSchemaValidation` (Optional): Prevents Helm from validating the
   values against the JSON Schema. Defaults to `false`.
 - `.disableTakeOwnership` (Optional): Disables ignoring the check for helm labels and annotations before taking
-  ownership of the existing resources during the Helm install action. Defaults to `false`.
+  ownership of the existing resources during the Helm upgrade action. Defaults to `false`.
 - `.disableWait` (Optional): Disables waiting for resources to be ready after
   upgrading the release. Defaults to `false`.
 - `.disableWaitForJobs` (Optional): Disables waiting for any Jobs to complete

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -494,8 +494,8 @@ The field offers the following subfields:
   rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`.
 - `.disableSchemaValidation` (Optional): Prevents Helm from validating the
   values against the JSON Schema. Defaults to `false`.
-- `.disableTakeOwnership` (Optional): Disables ignoring the check for helm labels and annotations before taking
-  ownership of the existing resources during the Helm install action. Defaults to `false`.
+- `.disableTakeOwnership` (Optional): Disables taking ownership of existing resources
+  during the Helm install action. Defaults to `false`.
 - `.disableWait` (Optional): Disables waiting for resources to be ready after
   the installation of the chart. Defaults to `false`.
 - `.disableWaitForJobs` (Optional): Disables waiting for any Jobs to complete
@@ -540,8 +540,8 @@ The field offers the following subfields:
   rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`.
 - `.disableSchemaValidation` (Optional): Prevents Helm from validating the
   values against the JSON Schema. Defaults to `false`.
-- `.disableTakeOwnership` (Optional): Disables ignoring the check for helm labels and annotations before taking
-  ownership of the existing resources during the Helm upgrade action. Defaults to `false`.
+- `.disableTakeOwnership` (Optional): Disables taking ownership of existing resources
+  during the Helm upgrade action. Defaults to `false`.
 - `.disableWait` (Optional): Disables waiting for resources to be ready after
   upgrading the release. Defaults to `false`.
 - `.disableWaitForJobs` (Optional): Disables waiting for any Jobs to complete

--- a/internal/action/install.go
+++ b/internal/action/install.go
@@ -68,6 +68,7 @@ func newInstall(config *helmaction.Configuration, obj *v2.HelmRelease, opts []In
 	install.ReleaseName = release.ShortenName(obj.GetReleaseName())
 	install.Namespace = obj.GetReleaseNamespace()
 	install.Timeout = obj.GetInstall().GetTimeout(obj.GetTimeout()).Duration
+	install.TakeOwnership = !obj.GetInstall().DisableTakeOwnership
 	install.Wait = !obj.GetInstall().DisableWait
 	install.WaitForJobs = !obj.GetInstall().DisableWaitForJobs
 	install.DisableHooks = obj.GetInstall().DisableHooks
@@ -76,7 +77,6 @@ func newInstall(config *helmaction.Configuration, obj *v2.HelmRelease, opts []In
 	install.Replace = obj.GetInstall().Replace
 	install.Devel = true
 	install.SkipCRDs = true
-	install.TakeOwnership = true
 
 	if obj.Spec.TargetNamespace != "" {
 		install.CreateNamespace = obj.GetInstall().CreateNamespace

--- a/internal/action/install_test.go
+++ b/internal/action/install_test.go
@@ -94,4 +94,24 @@ func Test_newInstall(t *testing.T) {
 		g.Expect(got.Atomic).To(BeTrue())
 		g.Expect(got.DryRun).To(BeTrue())
 	})
+
+	t.Run("disable take ownership", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "install",
+				Namespace: "install-ns",
+			},
+			Spec: v2.HelmReleaseSpec{
+				Install: &v2.Install{
+					DisableTakeOwnership: true,
+				},
+			},
+		}
+
+		got := newInstall(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.TakeOwnership).To(BeFalse())
+	})
 }

--- a/internal/action/upgrade.go
+++ b/internal/action/upgrade.go
@@ -69,6 +69,7 @@ func newUpgrade(config *helmaction.Configuration, obj *v2.HelmRelease, opts []Up
 	upgrade.ReuseValues = obj.GetUpgrade().PreserveValues
 	upgrade.MaxHistory = obj.GetMaxHistory()
 	upgrade.Timeout = obj.GetUpgrade().GetTimeout(obj.GetTimeout()).Duration
+	upgrade.TakeOwnership = !obj.GetUpgrade().DisableTakeOwnership
 	upgrade.Wait = !obj.GetUpgrade().DisableWait
 	upgrade.WaitForJobs = !obj.GetUpgrade().DisableWaitForJobs
 	upgrade.DisableHooks = obj.GetUpgrade().DisableHooks
@@ -77,7 +78,6 @@ func newUpgrade(config *helmaction.Configuration, obj *v2.HelmRelease, opts []Up
 	upgrade.Force = obj.GetUpgrade().Force
 	upgrade.CleanupOnFail = obj.GetUpgrade().CleanupOnFail
 	upgrade.Devel = true
-	upgrade.TakeOwnership = true
 
 	// If the user opted-in to allow DNS lookups, enable it.
 	if allowDNS, _ := features.Enabled(features.AllowDNSLookups); allowDNS {

--- a/internal/action/upgrade_test.go
+++ b/internal/action/upgrade_test.go
@@ -94,4 +94,24 @@ func Test_newUpgrade(t *testing.T) {
 		g.Expect(got.Install).To(BeTrue())
 		g.Expect(got.DryRun).To(BeTrue())
 	})
+
+	t.Run("disable take ownership", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "upgrade",
+				Namespace: "upgrade-ns",
+			},
+			Spec: v2.HelmReleaseSpec{
+				Upgrade: &v2.Upgrade{
+					DisableTakeOwnership: true,
+				},
+			},
+		}
+
+		got := newUpgrade(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.TakeOwnership).To(BeFalse())
+	})
 }


### PR DESCRIPTION
This change adds a new field called `disableTakeOwnership` to `.spec.install` and `.spec.upgrade`. The flag allows users to disable ignoring helm annotations and labels before taking ownership of existing resources during install and upgrade.

Closes https://github.com/fluxcd/helm-controller/issues/1139

xref: https://github.com/helm/helm/pull/13439