### PR TITLE
fix: use HelmRelease max history for rollback remediation

### DIFF
--- a/internal/action/rollback.go
+++ b/internal/action/rollback.go
@@ -65,6 +65,7 @@ func newRollback(config *helmaction.Configuration, obj *v2.HelmRelease, opts []R
 	rollback.Force = obj.GetRollback().Force
 	rollback.Recreate = obj.GetRollback().Recreate
 	rollback.CleanupOnFail = obj.GetRollback().CleanupOnFail
+	rollback.MaxHistory = obj.GetMaxHistory()
 
 	for _, opt := range opts {
 		opt(rollback)

--- a/internal/action/rollback_test.go
+++ b/internal/action/rollback_test.go
@@ -49,6 +49,7 @@ func Test_newRollback(t *testing.T) {
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(got.Timeout).To(Equal(obj.Spec.Rollback.Timeout.Duration))
 		g.Expect(got.Force).To(Equal(obj.Spec.Rollback.Force))
+		g.Expect(got.MaxHistory).To(Equal(obj.GetMaxHistory()))
 	})
 
 	t.Run("rollback to version", func(t *testing.T) {


### PR DESCRIPTION
Without this fix, HelmRelease stuck in infinite rollback remediation loop could create lots of revisions and Secrets for them, which can cause k8s control plane to be unresponsive or other components loading Secrets to crash OOM.

Infinite rollback remediation loop can happen e.g. in case both HelmRelease upgrade and rollback depend on a mutating or validating webhook availability and HelmRelease is configured with infinite rollback remediation, so failed upgrade triggers rollback remediation which can't succeed too and keeps on being retried, generating revision in every retry.