### PR TITLE
Add `DisableChartDigestTracking` feature gate

### DIFF
--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -217,6 +217,9 @@ The controller will automatically perform a Helm upgrade when the `OCIRepository
 detects a new digest in the OCI artifact stored in registry, even if the version
 inside `Chart.yaml` is unchanged.
 
+**Note:** Disabling the appending of the digest to the chart version can be done
+with the `--feature-gates=DisableChartDigestTracking=true` controller flag.
+
 **Warning:** One of `.spec.chart` or `.spec.chartRef` must be set, but not both.
 When switching from `.spec.chart` to `.spec.chartRef`, the controller will perform
 an Helm upgrade and will garbage collect the old HelmChart object.

--- a/internal/controller/helmrelease_controller_test.go
+++ b/internal/controller/helmrelease_controller_test.go
@@ -3926,7 +3926,8 @@ func Test_TryMutateChartWithSourceRevision(t *testing.T) {
 				},
 			}
 
-			_, err := mutateChartWithSourceRevision(c, s)
+			r := &HelmReleaseReconciler{}
+			_, err := r.mutateChartWithSourceRevision(c, s)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -58,6 +58,13 @@ const (
 	// without the need to upgrade the Helm release. But it can be disabled to
 	// avoid potential abuse of the adoption mechanism.
 	AdoptLegacyReleases = "AdoptLegacyReleases"
+
+	// DisableChartDigestTracking disables the tracking of digest changes
+	// for Helm OCI charts. When enabled, the controller will not trigger
+	// a Helm release upgrade if the chart version stays the same, but its
+	// digest changes. When enabled, the controller will not
+	// append the digest to the chart version in Chart.yaml.
+	DisableChartDigestTracking = "DisableChartDigestTracking"
 )
 
 var features = map[string]bool{
@@ -79,6 +86,9 @@ var features = map[string]bool{
 	// AdoptLegacyReleases
 	// opt-out from v0.37
 	AdoptLegacyReleases: true,
+	// DisableChartDigestTracking
+	// opt-in from v1.3.0
+	DisableChartDigestTracking: false,
 }
 
 // FeatureGates contains a list of all supported feature gates and

--- a/main.go
+++ b/main.go
@@ -181,6 +181,12 @@ func main() {
 		leaderElectionId = leaderelection.GenerateID(leaderElectionId, watchOptions.LabelSelector)
 	}
 
+	disableChartDigestTracking, err := features.Enabled(features.DisableChartDigestTracking)
+	if err != nil {
+		setupLog.Error(err, "unable to check feature gate DisableChartDigestTracking")
+		os.Exit(1)
+	}
+
 	// Set the managedFields owner for resources reconciled from Helm charts.
 	kube.ManagedFieldsManager = controllerName
 
@@ -269,14 +275,15 @@ func main() {
 	}
 
 	if err = (&controller.HelmReleaseReconciler{
-		Client:           mgr.GetClient(),
-		APIReader:        mgr.GetAPIReader(),
-		EventRecorder:    eventRecorder,
-		Metrics:          metricsH,
-		GetClusterConfig: ctrl.GetConfig,
-		ClientOpts:       clientOptions,
-		KubeConfigOpts:   kubeConfigOpts,
-		FieldManager:     controllerName,
+		Client:                     mgr.GetClient(),
+		APIReader:                  mgr.GetAPIReader(),
+		EventRecorder:              eventRecorder,
+		Metrics:                    metricsH,
+		GetClusterConfig:           ctrl.GetConfig,
+		ClientOpts:                 clientOptions,
+		KubeConfigOpts:             kubeConfigOpts,
+		FieldManager:               controllerName,
+		DisableChartDigestTracking: disableChartDigestTracking,
 	}).SetupWithManager(ctx, mgr, controller.HelmReleaseReconcilerOptions{
 		DependencyRequeueInterval: requeueDependency,
 		HTTPRetry:                 httpRetry,


### PR DESCRIPTION
Fix: https://github.com/fluxcd/flux2/issues/4910

When using `OCIRepository` for Helm charts that set the chart version as a label e.g. `app.kubernetes.io/version: {{ .Chart.Version }}`, helm-controller will fail to install the Helm release due to appending the digest to the chart version:

```
Helm upgrade failed  invalid: spec.template.labels: Invalid value: "0.9.3+4fda46fd8c4e": a valid label must be an empty string or consist of alphanumeric characters
```

This PR makes it possible to disable the chart digest tracking at controller level. When the feature gate is enabled, Flux will no longer trigger a Helm release upgrade if the digest changed unless the chart version changes too.

To deploy the release candidate and test the `DisableChartDigestTracking` feature gate, add the following patch to the flux-system overlay:

```yaml
patches:
  - target:
      kind: Deployment
      name: "helm-controller"
    patch: |
      - op: add
        path: /spec/template/spec/containers/0/args/-
        value: --feature-gates=DisableChartDigestTracking=true
      - op: replace
        path: /spec/template/spec/containers/0/image
        value: ghcr.io/fluxcd/helm-controller:rc-da305300
```