### PR TITLE
Record the last Helm release action duration in status

### DIFF
--- a/api/v2/helmrelease_types.go
+++ b/api/v2/helmrelease_types.go
@@ -1017,6 +1017,12 @@ type HelmReleaseStatus struct {
 	// +optional
 	LastAttemptedReleaseAction ReleaseAction `json:"lastAttemptedReleaseAction,omitempty"`
 
+	// LastAttemptedReleaseActionDuration is the duration of the last
+	// release action performed for this HelmRelease.
+	// +kubebuilder:validation:Type=string
+	// +optional
+	LastAttemptedReleaseActionDuration *metav1.Duration `json:"lastAttemptedReleaseActionDuration,omitempty"`
+
 	// Failures is the reconciliation failure count against the latest desired
 	// state. It is reset after a successful reconciliation.
 	// +optional

--- a/api/v2/zz_generated.deepcopy.go
+++ b/api/v2/zz_generated.deepcopy.go
@@ -423,6 +423,11 @@ func (in *HelmReleaseStatus) DeepCopyInto(out *HelmReleaseStatus) {
 			}
 		}
 	}
+	if in.LastAttemptedReleaseActionDuration != nil {
+		in, out := &in.LastAttemptedReleaseActionDuration, &out.LastAttemptedReleaseActionDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	out.ReconcileRequestStatus = in.ReconcileRequestStatus
 	out.ForceRequestStatus = in.ForceRequestStatus
 }

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -1183,6 +1183,11 @@ spec:
                 - install
                 - upgrade
                 type: string
+              lastAttemptedReleaseActionDuration:
+                description: |-
+                  LastAttemptedReleaseActionDuration is the duration of the last
+                  release action performed for this HelmRelease.
+                type: string
               lastAttemptedRevision:
                 description: |-
                   LastAttemptedRevision is the Source revision of the last reconciliation

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -1681,6 +1681,21 @@ HelmRelease. It is used to determine the active remediation strategy.</p>
 </tr>
 <tr>
 <td>
+<code>lastAttemptedReleaseActionDuration</code><br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LastAttemptedReleaseActionDuration is the duration of the last
+release action performed for this HelmRelease.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>failures</code><br>
 <em>
 int64

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -1986,6 +1986,11 @@ are `install` and `upgrade`.
 This field is used by the controller to determine the active remediation
 strategy for the HelmRelease.
 
+### Last Attempted Release Action Duration
+
+The helm-controller reports the duration of the last Helm release action it
+attempted to perform in the `.status.lastAttemptedReleaseActionDuration` field.
+
 ### Last Handled Reconcile At
 
 The helm-controller reports the last `reconcile.fluxcd.io/requestedAt`

--- a/internal/controller/helmrelease_controller_test.go
+++ b/internal/controller/helmrelease_controller_test.go
@@ -1861,6 +1861,8 @@ func TestHelmReleaseReconciler_reconcileReleaseFromOCIRepositorySource(t *testin
 		// to only have the leading 12 chars digest as build metadata (initial tag metadata overwritten)
 		g.Expect(obj.Status.LastAttemptedRevision).To(Equal("0.1.0" + "+" + dig))
 		g.Expect(obj.Status.LastAttemptedConfigDigest).To(Equal("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+		g.Expect(obj.Status.LastAttemptedReleaseAction).To(Equal(v2.ReleaseActionInstall))
+		g.Expect(obj.Status.LastAttemptedReleaseActionDuration).ToNot(BeNil())
 		g.Expect(obj.Status.LastAttemptedValuesChecksum).To(BeEmpty())
 
 		// change the chart revision with a new version (build metadata) to simulate a new digest
@@ -1875,6 +1877,8 @@ func TestHelmReleaseReconciler_reconcileReleaseFromOCIRepositorySource(t *testin
 		// to only have the leading 12 chars digest as build metadata (initial tag metadata overwritten)
 		g.Expect(obj.Status.LastAttemptedRevision).To(Equal("0.1.0" + "+" + "adebc5e3cbcd"))
 		g.Expect(obj.Status.LastAttemptedConfigDigest).To(Equal("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+		g.Expect(obj.Status.LastAttemptedReleaseAction).To(Equal(v2.ReleaseActionUpgrade))
+		g.Expect(obj.Status.LastAttemptedReleaseActionDuration).ToNot(BeNil())
 		g.Expect(obj.Status.LastAttemptedValuesChecksum).To(BeEmpty())
 	})
 

--- a/internal/reconcile/atomic_release_test.go
+++ b/internal/reconcile/atomic_release_test.go
@@ -1288,6 +1288,9 @@ func TestAtomicRelease_Reconcile_PostRenderers_Scenarios(t *testing.T) {
 
 			g.Expect(obj.Status.ObservedPostRenderersDigest).To(Equal(tt.wantDigest))
 			g.Expect(obj.Status.LastAttemptedReleaseAction).To(Equal(tt.wantReleaseAction))
+			if tt.wantReleaseAction != "" {
+				g.Expect(obj.Status.LastAttemptedReleaseActionDuration).ToNot(BeNil())
+			}
 		})
 	}
 }
@@ -2170,6 +2173,9 @@ func TestAtomicRelease_Reconcile_CommonMetadata_Scenarios(t *testing.T) {
 
 			g.Expect(obj.Status.ObservedCommonMetadataDigest).To(Equal(tt.wantDigest))
 			g.Expect(obj.Status.LastAttemptedReleaseAction).To(Equal(tt.wantReleaseAction))
+			if tt.wantReleaseAction != "" {
+				g.Expect(obj.Status.LastAttemptedReleaseActionDuration).ToNot(BeNil())
+			}
 		})
 	}
 }

--- a/internal/reconcile/install.go
+++ b/internal/reconcile/install.go
@@ -20,18 +20,20 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
-	"github.com/fluxcd/pkg/runtime/logger"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/fluxcd/pkg/chartutil"
 	"github.com/fluxcd/pkg/runtime/conditions"
+	"github.com/fluxcd/pkg/runtime/logger"
 
 	v2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/helm-controller/internal/action"
 	"github.com/fluxcd/helm-controller/internal/digest"
-	"github.com/fluxcd/pkg/chartutil"
 )
 
 // Install is an ActionReconciler which attempts to install a Helm release
@@ -72,6 +74,7 @@ func (r *Install) Reconcile(ctx context.Context, req *Request) error {
 		logBuf      = action.NewLogBuffer(action.NewDebugLog(ctrl.LoggerFrom(ctx).V(logger.DebugLevel)), 10)
 		obsReleases = make(observedReleases)
 		cfg         = r.configFactory.Build(logBuf.Log, observeRelease(obsReleases))
+		startTime   = time.Now()
 	)
 
 	defer summarize(req)
@@ -90,6 +93,9 @@ func (r *Install) Reconcile(ctx context.Context, req *Request) error {
 
 	// Run the Helm install action.
 	_, err := action.Install(ctx, cfg, req.Object, req.Chart, req.Values)
+
+	// Record the action duration in status.
+	req.Object.Status.LastAttemptedReleaseActionDuration = &metav1.Duration{Duration: time.Since(startTime)}
 
 	// Record the history of releases observed during the install.
 	obsReleases.recordOnObject(req.Object, mutateOCIDigest)

--- a/internal/reconcile/install_test.go
+++ b/internal/reconcile/install_test.go
@@ -38,9 +38,8 @@ import (
 
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/fluxcd/pkg/runtime/conditions"
-
 	"github.com/fluxcd/pkg/chartutil"
+	"github.com/fluxcd/pkg/runtime/conditions"
 
 	v2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/helm-controller/internal/action"
@@ -299,6 +298,8 @@ func TestInstall_Reconcile(t *testing.T) {
 			g.Expect(obj.Status.Failures).To(Equal(tt.expectFailures))
 			g.Expect(obj.Status.InstallFailures).To(Equal(tt.expectInstallFailures))
 			g.Expect(obj.Status.UpgradeFailures).To(Equal(tt.expectUpgradeFailures))
+			g.Expect(obj.Status.LastAttemptedReleaseAction).To(Equal(v2.ReleaseActionInstall))
+			g.Expect(obj.Status.LastAttemptedReleaseActionDuration).ToNot(BeNil())
 		})
 	}
 }

--- a/internal/reconcile/upgrade_test.go
+++ b/internal/reconcile/upgrade_test.go
@@ -38,9 +38,8 @@ import (
 
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/fluxcd/pkg/runtime/conditions"
-
 	"github.com/fluxcd/pkg/chartutil"
+	"github.com/fluxcd/pkg/runtime/conditions"
 
 	v2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/helm-controller/internal/action"
@@ -430,6 +429,8 @@ func TestUpgrade_Reconcile(t *testing.T) {
 			g.Expect(obj.Status.Failures).To(Equal(tt.expectFailures))
 			g.Expect(obj.Status.InstallFailures).To(Equal(tt.expectInstallFailures))
 			g.Expect(obj.Status.UpgradeFailures).To(Equal(tt.expectUpgradeFailures))
+			g.Expect(obj.Status.LastAttemptedReleaseAction).To(Equal(v2.ReleaseActionUpgrade))
+			g.Expect(obj.Status.LastAttemptedReleaseActionDuration).ToNot(BeNil())
 		})
 	}
 }


### PR DESCRIPTION
This PR makes the helm-controller report the duration of the last Helm release action it attempted to perform in the `.status.lastAttemptedReleaseActionDuration` field. Recording the install or upgrade duration information can be useful for debugging purposes.