### PR TITLE
Add recommended settings for production environments 

### DIFF
--- a/internal/controller/helmrelease_controller.go
+++ b/internal/controller/helmrelease_controller.go
@@ -204,9 +204,8 @@ func (r *HelmReleaseReconciler) reconcileRelease(ctx context.Context, patchHelpe
 	log := ctrl.LoggerFrom(ctx)
 
 	// Mark the resource as under reconciliation.
-	const progressingMsg = "Fulfilling prerequisites"
-	conditions.MarkReconciling(obj, meta.ProgressingReason, progressingMsg)
-	conditions.MarkUnknown(obj, meta.ReadyCondition, meta.ProgressingReason, progressingMsg)
+	// We set Ready=Unknown down below after we assess the readiness of dependencies and the source.
+	conditions.MarkReconciling(obj, meta.ProgressingReason, "Fulfilling prerequisites")
 	if err := patchHelper.Patch(ctx, obj, patch.WithOwnedConditions{Conditions: intreconcile.OwnedConditions}, patch.WithFieldOwner(r.FieldManager)); err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
This PR contains the following changes:
- Add recommended settings for HelmRelease configuration on production environments
- Remove redundant `Read=Unknown` setting at the start of the reconciliation introduced in #1249. The `Ready` status condition is set to `Unknown` after asserting the readiness of dependencies and the source.

Fix: #1320