### PR TITLE
Add --override-manager flag for server-side apply drift detection

### DIFF
--- a/internal/controller/helmrelease_controller.go
+++ b/internal/controller/helmrelease_controller.go
@@ -89,13 +89,14 @@ type HelmReleaseReconciler struct {
 
 	// Kubernetes configuration
 
-	FieldManager          string
-	DefaultServiceAccount string
-	GetClusterConfig      func() (*rest.Config, error)
-	ClientOpts            runtimeClient.Options
-	KubeConfigOpts        runtimeClient.KubeConfigOptions
-	APIReader             client.Reader
-	TokenCache            *cache.TokenCache
+	FieldManager            string
+	DisallowedFieldManagers []string
+	DefaultServiceAccount   string
+	GetClusterConfig        func() (*rest.Config, error)
+	ClientOpts              runtimeClient.Options
+	KubeConfigOpts          runtimeClient.KubeConfigOptions
+	APIReader               client.Reader
+	TokenCache              *cache.TokenCache
 
 	// Retry and requeue configuration
 
@@ -393,7 +394,7 @@ func (r *HelmReleaseReconciler) reconcileRelease(ctx context.Context, patchHelpe
 	}
 
 	// Off we go!
-	if err = intreconcile.NewAtomicRelease(patchHelper, cfg, r.EventRecorder, r.FieldManager).Reconcile(ctx, &intreconcile.Request{
+	if err = intreconcile.NewAtomicRelease(patchHelper, cfg, r.EventRecorder, r.FieldManager, r.DisallowedFieldManagers).Reconcile(ctx, &intreconcile.Request{
 		Object: obj,
 		Chart:  loadedChart,
 		Values: values,

--- a/internal/reconcile/atomic_release_test.go
+++ b/internal/reconcile/atomic_release_test.go
@@ -177,7 +177,7 @@ func TestAtomicRelease_Reconcile(t *testing.T) {
 			Chart:  testutil.BuildChart(testutil.ChartWithTestHook()),
 			Values: nil,
 		}
-		g.Expect(NewAtomicRelease(patchHelper, cfg, recorder, testFieldManager).Reconcile(context.TODO(), req)).ToNot(HaveOccurred())
+		g.Expect(NewAtomicRelease(patchHelper, cfg, recorder, testFieldManager, nil).Reconcile(context.TODO(), req)).ToNot(HaveOccurred())
 
 		g.Expect(obj.Status.Conditions).To(conditions.MatchConditions([]metav1.Condition{
 			{
@@ -206,7 +206,7 @@ func TestAtomicRelease_Reconcile(t *testing.T) {
 		g.Expect(obj.Status.InstallFailures).To(BeZero())
 		g.Expect(obj.Status.UpgradeFailures).To(BeZero())
 
-		endState, err := DetermineReleaseState(ctx, cfg, req)
+		endState, err := DetermineReleaseState(ctx, cfg, req, nil)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(endState).To(Equal(ReleaseState{Status: ReleaseStatusInSync}))
 	})
@@ -1229,7 +1229,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 				Values: tt.values,
 			}
 
-			err = NewAtomicRelease(patchHelper, cfg, recorder, testFieldManager).Reconcile(context.TODO(), req)
+			err = NewAtomicRelease(patchHelper, cfg, recorder, testFieldManager, nil).Reconcile(context.TODO(), req)
 			wantErr := BeNil()
 			if tt.wantErr != nil {
 				wantErr = MatchError(tt.wantErr)
@@ -1460,7 +1460,7 @@ func TestAtomicRelease_Reconcile_PostRenderers_Scenarios(t *testing.T) {
 				Values: tt.values,
 			}
 
-			err = NewAtomicRelease(patchHelper, cfg, recorder, testFieldManager).Reconcile(context.TODO(), req)
+			err = NewAtomicRelease(patchHelper, cfg, recorder, testFieldManager, nil).Reconcile(context.TODO(), req)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(obj.Status.ObservedPostRenderersDigest).To(Equal(tt.wantDigest))
@@ -2401,7 +2401,7 @@ func TestAtomicRelease_Reconcile_CommonMetadata_Scenarios(t *testing.T) {
 				Values: tt.values,
 			}
 
-			err = NewAtomicRelease(patchHelper, cfg, recorder, testFieldManager).Reconcile(context.TODO(), req)
+			err = NewAtomicRelease(patchHelper, cfg, recorder, testFieldManager, nil).Reconcile(context.TODO(), req)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(obj.Status.ObservedCommonMetadataDigest).To(Equal(tt.wantDigest))

--- a/internal/reconcile/state.go
+++ b/internal/reconcile/state.go
@@ -89,7 +89,7 @@ type ReleaseState struct {
 // DetermineReleaseState determines the state of the Helm release as compared
 // to the v2.HelmRelease object. It returns a ReleaseState that indicates
 // the status of the release, and an error if the state could not be determined.
-func DetermineReleaseState(ctx context.Context, cfg *action.ConfigFactory, req *Request) (ReleaseState, error) {
+func DetermineReleaseState(ctx context.Context, cfg *action.ConfigFactory, req *Request, disallowedFieldManagers []string) (ReleaseState, error) {
 	rls, err := action.LastRelease(cfg.Build(nil), req.Object.GetReleaseName())
 	if err != nil {
 		if errors.Is(err, action.ErrReleaseNotFound) {
@@ -188,7 +188,7 @@ func DetermineReleaseState(ctx context.Context, cfg *action.ConfigFactory, req *
 
 		// Confirm the cluster state matches the desired config.
 		if diffOpts := req.Object.GetDriftDetection(); diffOpts.MustDetectChanges() {
-			diffSet, err := action.Diff(ctx, cfg.Build(nil), rls, kube.ManagedFieldsManager, req.Object.GetDriftDetection().Ignore...)
+			diffSet, err := action.Diff(ctx, cfg.Build(nil), rls, kube.ManagedFieldsManager, disallowedFieldManagers, req.Object.GetDriftDetection().Ignore...)
 			hasChanges := diffSet.HasChanges()
 			if err != nil {
 				if !hasChanges {

--- a/internal/reconcile/state_test.go
+++ b/internal/reconcile/state_test.go
@@ -636,7 +636,7 @@ func Test_DetermineReleaseState(t *testing.T) {
 				Object: obj,
 				Chart:  tt.chart,
 				Values: tt.values,
-			})
+			}, nil)
 			if tt.wantErr {
 				g.Expect(got).To(BeNil())
 				g.Expect(err).To(HaveOccurred())
@@ -816,7 +816,7 @@ func TestDetermineReleaseState_DriftDetection(t *testing.T) {
 				Object: obj,
 				Chart:  testutil.BuildChart(),
 				Values: rls.Config,
-			})
+			}, nil)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			want := tt.want(releaseNamespace)

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	v2 "github.com/fluxcd/helm-controller/api/v2"
+
 	intdigest "github.com/fluxcd/helm-controller/internal/digest"
 
 	// +kubebuilder:scaffold:imports
@@ -105,6 +106,7 @@ func main() {
 		oomWatchMaxMemoryPath           string
 		oomWatchCurrentMemoryPath       string
 		snapshotDigestAlgo              string
+		disallowedFieldManagers         []string
 		tokenCacheOptions               cache.TokenFlags
 		defaultKubeConfigServiceAccount string
 	)
@@ -137,6 +139,8 @@ func main() {
 		"The path to the cgroup current memory usage file. Requires feature gate 'OOMWatch' to be enabled. If not set, the path will be automatically detected.")
 	flag.StringVar(&snapshotDigestAlgo, "snapshot-digest-algo", intdigest.Canonical.String(),
 		"The algorithm to use to calculate the digest of Helm release storage snapshots.")
+	flag.StringArrayVar(&disallowedFieldManagers, "override-manager", []string{},
+		"List of field managers to override during drift detection.")
 
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
@@ -354,6 +358,7 @@ func main() {
 		DependencyRequeueInterval:  requeueDependency,
 		ArtifactFetchRetries:       httpRetry,
 		AllowExternalArtifact:      allowExternalArtifact,
+		DisallowedFieldManagers:    disallowedFieldManagers,
 	}).SetupWithManager(ctx, mgr, controller.HelmReleaseReconcilerOptions{
 		RateLimiter:            helper.GetRateLimiter(rateLimiterOptions),
 		WatchConfigs:           watchConfigs,


### PR DESCRIPTION
This flag allows specifying field managers whose ownership should be transferred to the helm-controller before performing drift detection. When a disallowed field manager is detected on a managed resource, its field ownership is replaced with the helm-controller's field owner, enabling proper drift detection for fields that were previously modified by other controllers or tools (e.g., kubectl).

This feature mirrors the --override-manager flag available in FluxCD's kustomize-controller, providing consistent behavior across Flux components for managing server-side apply field ownership conflicts.

Since it doesn't change the default behavior, the implementation doesn't introduce any breaking changes.

Fix: https://github.com/fluxcd/helm-controller/issues/896