### PR TITLE
Introduce description field to .status.history

### DIFF
--- a/api/v2/snapshot_types.go
+++ b/api/v2/snapshot_types.go
@@ -155,6 +155,10 @@ type Snapshot struct {
 	// Status is the current state of the release.
 	// +required
 	Status string `json:"status"`
+	// Description is the human-readable description of the current state
+	// of the release.
+	// +required
+	Description string `json:"description"`
 	// ChartName is the chart name of the release object in storage.
 	// +required
 	ChartName string `json:"chartName"`

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -1232,6 +1232,11 @@ spec:
                       description: Deleted is when the release was deleted.
                       format: date-time
                       type: string
+                    description:
+                      description: |-
+                        Description is the human-readable description of the current state
+                        of the release.
+                      type: string
                     digest:
                       description: |-
                         Digest is the checksum of the release object in storage.
@@ -1291,6 +1296,7 @@ spec:
                   - chartName
                   - chartVersion
                   - configDigest
+                  - description
                   - digest
                   - firstDeployed
                   - lastDeployed
@@ -2579,6 +2585,11 @@ spec:
                       description: Deleted is when the release was deleted.
                       format: date-time
                       type: string
+                    description:
+                      description: |-
+                        Description is the human-readable description of the current state
+                        of the release.
+                      type: string
                     digest:
                       description: |-
                         Digest is the checksum of the release object in storage.
@@ -2638,6 +2649,7 @@ spec:
                   - chartName
                   - chartVersion
                   - configDigest
+                  - description
                   - digest
                   - firstDeployed
                   - lastDeployed

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -2738,6 +2738,18 @@ string
 </tr>
 <tr>
 <td>
+<code>description</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Description is the human-readable description of the current state
+of the release.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>chartName</code><br>
 <em>
 string

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -1954,6 +1954,7 @@ status:
       namespace: podinfo
       ociDigest: sha256:0cc9a8446c95009ef382f5eade883a67c257f77d50f84e78ecef2aac9428d1e5
       status: deployed
+      description: Upgrade complete
       testHooks:
         podinfo-grpc-test-goyey:
           lastCompleted: "2024-05-07T04:55:11Z"
@@ -1971,6 +1972,7 @@ status:
       namespace: podinfo
       ociDigest: sha256:cdd538a0167e4b51152b71a477e51eb6737553510ce8797dbcc537e1342311bb
       status: superseded
+      description: Install complete
       testHooks:
         podinfo-grpc-test-q0ucx:
           lastCompleted: "2024-05-07T04:54:25Z"

--- a/internal/release/observation.go
+++ b/internal/release/observation.go
@@ -172,6 +172,7 @@ func ObservedToSnapshot(rls Observation) *v2.Snapshot {
 		LastDeployed:  metav1.NewTime(rls.Info.LastDeployed),
 		Deleted:       metav1.NewTime(rls.Info.Deleted),
 		Status:        rls.Info.Status.String(),
+		Description:   rls.Info.Description,
 		OCIDigest:     rls.OCIDigest,
 	}
 }


### PR DESCRIPTION
In Helm's upcoming Release API v2 (coming for supporting Chart API v3), the `status` field may get a fine-grained value:

https://github.com/banjoh/helm/pull/1

`deployed` -> `installed`, `upgraded`, `rolledback`

Currently, `status` already has `uninstalled`.