### PR TITLE
Track action in snapshots

### DIFF
--- a/api/v2/helmrelease_types.go
+++ b/api/v2/helmrelease_types.go
@@ -1195,6 +1195,12 @@ const (
 	ReleaseActionInstall ReleaseAction = "install"
 	// ReleaseActionUpgrade represents a Helm upgrade action.
 	ReleaseActionUpgrade ReleaseAction = "upgrade"
+	// ReleaseActionRollback represents a Helm rollback action.
+	ReleaseActionRollback ReleaseAction = "rollback"
+	// ReleaseActionUninstall represents a Helm uninstall action.
+	ReleaseActionUninstall ReleaseAction = "uninstall"
+	// ReleaseActionUninstallRemediation represents a Helm uninstall action for remediation.
+	ReleaseActionUninstallRemediation ReleaseAction = "uninstall-remediation"
 )
 
 // HelmReleaseStatus defines the observed state of a HelmRelease.

--- a/api/v2/snapshot_types.go
+++ b/api/v2/snapshot_types.go
@@ -135,8 +135,8 @@ func (in *Snapshots) TruncateIgnoringPreviousSnapshots() {
 // as managed by the controller.
 type Snapshot struct {
 	// APIVersion is the API version of the Snapshot.
-	// Provisional: when the calculation method of the Digest field is changed,
-	// this field will be used to distinguish between the old and new methods.
+	// When the calculation method of the Digest field is changed, this
+	// field will be used to distinguish between the old and new methods.
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Digest is the checksum of the release object in storage.
@@ -155,6 +155,9 @@ type Snapshot struct {
 	// Status is the current state of the release.
 	// +required
 	Status string `json:"status"`
+	// Action is the action that resulted in this snapshot being created.
+	// +optional
+	Action ReleaseAction `json:"action,omitempty"`
 	// ChartName is the chart name of the release object in storage.
 	// +required
 	ChartName string `json:"chartName"`
@@ -246,6 +249,14 @@ func (in *Snapshot) Targets(name, namespace string, version int) bool {
 		return in.Name == name && in.Namespace == namespace && in.Version == version
 	}
 	return false
+}
+
+// GetAction returns the ReleaseAction for the Snapshot.
+func (in *Snapshot) GetAction() ReleaseAction {
+	if in == nil {
+		return ""
+	}
+	return in.Action
 }
 
 // TestHookStatus holds the status information for a test hook as observed

--- a/api/v2/snapshot_types_test.go
+++ b/api/v2/snapshot_types_test.go
@@ -297,6 +297,57 @@ func TestSnapshots_Truncate(t *testing.T) {
 	}
 }
 
+func TestSnapshot_GetAction(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot *Snapshot
+		want     ReleaseAction
+	}{
+		{
+			name:     "nil snapshot",
+			snapshot: nil,
+			want:     "",
+		},
+		{
+			name:     "empty action",
+			snapshot: &Snapshot{},
+			want:     "",
+		},
+		{
+			name:     "install action",
+			snapshot: &Snapshot{Action: ReleaseActionInstall},
+			want:     ReleaseActionInstall,
+		},
+		{
+			name:     "upgrade action",
+			snapshot: &Snapshot{Action: ReleaseActionUpgrade},
+			want:     ReleaseActionUpgrade,
+		},
+		{
+			name:     "rollback action",
+			snapshot: &Snapshot{Action: ReleaseActionRollback},
+			want:     ReleaseActionRollback,
+		},
+		{
+			name:     "uninstall action",
+			snapshot: &Snapshot{Action: ReleaseActionUninstall},
+			want:     ReleaseActionUninstall,
+		},
+		{
+			name:     "uninstall-remediation action",
+			snapshot: &Snapshot{Action: ReleaseActionUninstallRemediation},
+			want:     ReleaseActionUninstallRemediation,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.snapshot.GetAction(); got != tt.want {
+				t.Errorf("GetAction() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSnapshots_TruncateIgnoringPreviousSnapshots(t *testing.T) {
 	tests := []struct {
 		name string

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -1203,11 +1203,15 @@ spec:
                     Snapshot captures a point-in-time copy of the status information for a Helm release,
                     as managed by the controller.
                   properties:
+                    action:
+                      description: Action is the action that resulted in this snapshot
+                        being created.
+                      type: string
                     apiVersion:
                       description: |-
                         APIVersion is the API version of the Snapshot.
-                        Provisional: when the calculation method of the Digest field is changed,
-                        this field will be used to distinguish between the old and new methods.
+                        When the calculation method of the Digest field is changed, this
+                        field will be used to distinguish between the old and new methods.
                       type: string
                     appVersion:
                       description: AppVersion is the chart app version of the release
@@ -2550,11 +2554,15 @@ spec:
                     Snapshot captures a point-in-time copy of the status information for a Helm release,
                     as managed by the controller.
                   properties:
+                    action:
+                      description: Action is the action that resulted in this snapshot
+                        being created.
+                      type: string
                     apiVersion:
                       description: |-
                         APIVersion is the API version of the Snapshot.
-                        Provisional: when the calculation method of the Digest field is changed,
-                        this field will be used to distinguish between the old and new methods.
+                        When the calculation method of the Digest field is changed, this
+                        field will be used to distinguish between the old and new methods.
                       type: string
                     appVersion:
                       description: AppVersion is the chart app version of the release

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -2408,7 +2408,8 @@ Kustomize
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseStatus">HelmReleaseStatus</a>)
+<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseStatus">HelmReleaseStatus</a>, 
+<a href="#helm.toolkit.fluxcd.io/v2.Snapshot">Snapshot</a>)
 </p>
 <p>ReleaseAction is the action to perform a Helm release.</p>
 <h3 id="helm.toolkit.fluxcd.io/v2.Remediation">Remediation
@@ -2676,8 +2677,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>APIVersion is the API version of the Snapshot.
-Provisional: when the calculation method of the Digest field is changed,
-this field will be used to distinguish between the old and new methods.</p>
+When the calculation method of the Digest field is changed, this
+field will be used to distinguish between the old and new methods.</p>
 </td>
 </tr>
 <tr>
@@ -2734,6 +2735,20 @@ string
 </td>
 <td>
 <p>Status is the current state of the release.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>action</code><br>
+<em>
+<a href="#helm.toolkit.fluxcd.io/v2.ReleaseAction">
+ReleaseAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Action is the action that resulted in this snapshot being created.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -1954,6 +1954,7 @@ status:
       namespace: podinfo
       ociDigest: sha256:0cc9a8446c95009ef382f5eade883a67c257f77d50f84e78ecef2aac9428d1e5
       status: deployed
+      action: upgrade
       testHooks:
         podinfo-grpc-test-goyey:
           lastCompleted: "2024-05-07T04:55:11Z"
@@ -1971,6 +1972,7 @@ status:
       namespace: podinfo
       ociDigest: sha256:cdd538a0167e4b51152b71a477e51eb6737553510ce8797dbcc537e1342311bb
       status: superseded
+      action: install
       testHooks:
         podinfo-grpc-test-q0ucx:
           lastCompleted: "2024-05-07T04:54:25Z"

--- a/internal/reconcile/atomic_release_test.go
+++ b/internal/reconcile/atomic_release_test.go
@@ -276,7 +276,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			values: nil,
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					observeReleaseWithAction(releases[1], v2.ReleaseActionUpgrade),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
 			},
@@ -305,7 +305,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			values: map[string]any{"foo": "baz"},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					observeReleaseWithAction(releases[1], v2.ReleaseActionUpgrade),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
 			},
@@ -331,7 +331,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[len(releases)-1])),
+					observeReleaseWithAction(releases[len(releases)-1], v2.ReleaseActionUpgrade),
 				}
 			},
 		},
@@ -365,7 +365,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[len(releases)-1])),
+					observeReleaseWithAction(releases[len(releases)-1], v2.ReleaseActionUpgrade),
 				}
 			},
 		},
@@ -407,7 +407,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[len(releases)-1])),
+					observeReleaseWithAction(releases[len(releases)-1], v2.ReleaseActionUpgrade),
 				}
 			},
 		},
@@ -416,7 +416,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionInstall),
 				}
 			},
 		},
@@ -436,7 +436,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					observeReleaseWithAction(releases[1], v2.ReleaseActionUpgrade),
 				}
 			},
 		},
@@ -480,7 +480,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[len(releases)-1])),
+					observeReleaseWithAction(releases[len(releases)-1], v2.ReleaseActionUpgrade),
 				}
 			},
 		},
@@ -524,7 +524,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[len(releases)-1])),
+					observeReleaseWithAction(releases[len(releases)-1], v2.ReleaseActionUpgrade),
 				}
 			},
 		},
@@ -548,7 +548,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionInstall),
 				}
 			},
 		},
@@ -600,7 +600,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[len(releases)-1])),
+					observeReleaseWithAction(releases[len(releases)-1], v2.ReleaseActionUpgrade),
 				}
 			},
 		},
@@ -609,7 +609,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(testutil.ChartWithFailingHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionInstall),
 				}
 			},
 			wantErr: ErrExceededMaxRetries,
@@ -629,7 +629,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(testutil.ChartWithFailingHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionUninstallRemediation),
 				}
 			},
 			wantErr: ErrExceededMaxRetries,
@@ -650,7 +650,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(testutil.ChartWithFailingHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionInstall),
 				}
 			},
 			wantErr: ErrRetryAfterInterval,
@@ -672,7 +672,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			},
 			chart: testutil.BuildChart(testutil.ChartWithFailingTestHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
-				snap := release.ObservedToSnapshot(release.ObserveRelease(releases[0]))
+				snap := observeReleaseWithAction(releases[0], v2.ReleaseActionUninstallRemediation)
 				snap.SetTestHooks(release.TestHooksFromRelease(releases[0]))
 
 				return v2.Snapshots{
@@ -699,7 +699,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			},
 			chart: testutil.BuildChart(testutil.ChartWithFailingTestHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
-				snap := release.ObservedToSnapshot(release.ObserveRelease(releases[0]))
+				snap := observeReleaseWithAction(releases[0], v2.ReleaseActionInstall)
 				snap.SetTestHooks(release.TestHooksFromRelease(releases[0]))
 
 				return v2.Snapshots{
@@ -718,7 +718,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			},
 			chart: testutil.BuildChart(testutil.ChartWithFailingTestHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
-				snap := release.ObservedToSnapshot(release.ObserveRelease(releases[0]))
+				snap := observeReleaseWithAction(releases[0], v2.ReleaseActionInstall)
 				snap.SetTestHooks(release.TestHooksFromRelease(releases[0]))
 
 				return v2.Snapshots{
@@ -771,7 +771,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(testutil.ChartWithFailingHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					observeReleaseWithAction(releases[1], v2.ReleaseActionUpgrade),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
 			},
@@ -807,9 +807,9 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(testutil.ChartWithFailingHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[2])),
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[2], v2.ReleaseActionRollback),
+					observeReleaseWithAction(releases[1], v2.ReleaseActionUpgrade),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionRollback),
 				}
 			},
 			wantErr: ErrExceededMaxRetries,
@@ -849,7 +849,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(testutil.ChartWithFailingHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					observeReleaseWithAction(releases[1], v2.ReleaseActionUninstallRemediation),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
 			},
@@ -886,7 +886,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			chart: testutil.BuildChart(testutil.ChartWithFailingHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					observeReleaseWithAction(releases[1], v2.ReleaseActionUpgrade),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
 			},
@@ -924,11 +924,11 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			},
 			chart: testutil.BuildChart(testutil.ChartWithFailingTestHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
-				testedSnap := release.ObservedToSnapshot(release.ObserveRelease(releases[1]))
+				testedSnap := observeReleaseWithAction(releases[1], v2.ReleaseActionRollback)
 				testedSnap.SetTestHooks(release.TestHooksFromRelease(releases[1]))
 
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[2])),
+					observeReleaseWithAction(releases[2], v2.ReleaseActionRollback),
 					testedSnap,
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
@@ -968,7 +968,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			},
 			chart: testutil.BuildChart(testutil.ChartWithFailingTestHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
-				testedSnap := release.ObservedToSnapshot(release.ObserveRelease(releases[1]))
+				testedSnap := observeReleaseWithAction(releases[1], v2.ReleaseActionUpgrade)
 				testedSnap.SetTestHooks(release.TestHooksFromRelease(releases[1]))
 
 				return v2.Snapshots{
@@ -1006,7 +1006,7 @@ func TestAtomicRelease_Reconcile_Scenarios(t *testing.T) {
 			},
 			chart: testutil.BuildChart(testutil.ChartWithFailingTestHook()),
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
-				testedSnap := release.ObservedToSnapshot(release.ObserveRelease(releases[1]))
+				testedSnap := observeReleaseWithAction(releases[1], v2.ReleaseActionUpgrade)
 				testedSnap.SetTestHooks(release.TestHooksFromRelease(releases[1]))
 
 				return v2.Snapshots{

--- a/internal/reconcile/install.go
+++ b/internal/reconcile/install.go
@@ -96,7 +96,9 @@ func (r *Install) Reconcile(ctx context.Context, req *Request) error {
 	req.Object.Status.LastAttemptedReleaseActionDuration = &metav1.Duration{Duration: time.Since(startTime)}
 
 	// Record the history of releases observed during the install.
-	obsReleases.recordOnObject(req.Object, mutateOCIDigest)
+	obsReleases.recordOnObject(req.Object,
+		mutateOCIDigest,
+		mutateAction(v2.ReleaseActionInstall))
 
 	if err != nil {
 		r.failure(req, logBuf, err)

--- a/internal/reconcile/install_test.go
+++ b/internal/reconcile/install_test.go
@@ -100,7 +100,11 @@ func TestInstall_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[0])
+						obs.Action = v2.ReleaseActionInstall
+						return release.ObservedToSnapshot(obs)
+					}(),
 				}
 			},
 			expectInventory: func(namespace string) *v2.ResourceInventory {
@@ -125,7 +129,11 @@ func TestInstall_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[0])
+						obs.Action = v2.ReleaseActionInstall
+						return release.ObservedToSnapshot(obs)
+					}(),
 				}
 			},
 			expectFailures:        1,
@@ -184,7 +192,11 @@ func TestInstall_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[1])
+						obs.Action = v2.ReleaseActionInstall
+						return release.ObservedToSnapshot(obs)
+					}(),
 				}
 			},
 		},
@@ -212,7 +224,11 @@ func TestInstall_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[0])
+						obs.Action = v2.ReleaseActionInstall
+						return release.ObservedToSnapshot(obs)
+					}(),
 				}
 			},
 		},
@@ -235,7 +251,11 @@ func TestInstall_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[0])
+						obs.Action = v2.ReleaseActionInstall
+						return release.ObservedToSnapshot(obs)
+					}(),
 				}
 			},
 		},
@@ -251,7 +271,11 @@ func TestInstall_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[0])
+						obs.Action = v2.ReleaseActionInstall
+						return release.ObservedToSnapshot(obs)
+					}(),
 				}
 			},
 			expectInventory: func(namespace string) *v2.ResourceInventory {
@@ -374,8 +398,10 @@ func TestInstall_Reconcile_withSubchartWithCRDs(t *testing.T) {
 	}
 
 	expectHistory := func(releases []*helmrelease.Release) v2.Snapshots {
+		obs := release.ObserveRelease(releases[0])
+		obs.Action = v2.ReleaseActionInstall
 		return v2.Snapshots{
-			release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+			release.ObservedToSnapshot(obs),
 		}
 	}
 

--- a/internal/reconcile/release.go
+++ b/internal/reconcile/release.go
@@ -113,9 +113,19 @@ func mutateOCIDigest(obj *v2.HelmRelease, obs release.Observation) release.Obser
 	return obs
 }
 
-func releaseToObservation(rls *helmreleasev1.Release, snapshot *v2.Snapshot) release.Observation {
+func mutateAction(action v2.ReleaseAction) func(obj *v2.HelmRelease, obs release.Observation) release.Observation {
+	return func(obj *v2.HelmRelease, obs release.Observation) release.Observation {
+		obs.Action = action
+		return obs
+	}
+}
+
+func releaseToObservation(rls *helmreleasev1.Release,
+	snapshot *v2.Snapshot, action v2.ReleaseAction) release.Observation {
+
 	obs := release.ObserveRelease(rls)
 	obs.OCIDigest = snapshot.OCIDigest
+	obs.Action = action
 	return obs
 }
 

--- a/internal/reconcile/release_test.go
+++ b/internal/reconcile/release_test.go
@@ -33,6 +33,7 @@ import (
 
 	v2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/helm-controller/internal/action"
+	"github.com/fluxcd/helm-controller/internal/release"
 )
 
 const (
@@ -555,6 +556,48 @@ func mockLogBuffer() *action.LogBuffer {
 	return buf
 }
 
+func Test_mutateAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		action v2.ReleaseAction
+	}{
+		{
+			name:   "install action",
+			action: v2.ReleaseActionInstall,
+		},
+		{
+			name:   "upgrade action",
+			action: v2.ReleaseActionUpgrade,
+		},
+		{
+			name:   "rollback action",
+			action: v2.ReleaseActionRollback,
+		},
+		{
+			name:   "uninstall action",
+			action: v2.ReleaseActionUninstall,
+		},
+		{
+			name:   "uninstall-remediation action",
+			action: v2.ReleaseActionUninstallRemediation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			obs := release.Observation{
+				Name:    mockReleaseName,
+				Version: 1,
+			}
+			mutator := mutateAction(tt.action)
+			result := mutator(&v2.HelmRelease{}, obs)
+			g.Expect(result.Action).To(Equal(tt.action))
+		})
+	}
+}
+
 func Test_RecordOnObject(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -728,5 +771,30 @@ func Test_RecordOnObject(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 		})
 	}
+}
 
+func Test_RecordOnObject_withAction(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := &v2.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mockReleaseName,
+			Namespace: mockReleaseNamespace,
+		},
+	}
+	r := observedReleases{
+		1: {
+			Name:    mockReleaseName,
+			Version: 1,
+			ChartMetadata: chart.Metadata{
+				Name:    mockReleaseName,
+				Version: "1.0.0",
+			},
+		},
+	}
+	r.recordOnObject(obj, mutateOCIDigest, mutateAction(v2.ReleaseActionInstall))
+
+	g.Expect(obj.Status.History).To(HaveLen(1))
+	g.Expect(obj.Status.History[0].Action).To(Equal(v2.ReleaseActionInstall))
+	g.Expect(obj.Status.History[0].Name).To(Equal(mockReleaseName))
 }

--- a/internal/reconcile/rollback_remediation.go
+++ b/internal/reconcile/rollback_remediation.go
@@ -187,7 +187,7 @@ func observeRollback(obj *v2.HelmRelease) storage.ObserveFunc {
 		for i := range obj.Status.History {
 			snap := obj.Status.History[i]
 			if snap.Targets(rls.Name, rls.Namespace, rls.Version) {
-				newSnap := release.ObservedToSnapshot(releaseToObservation(rls, snap))
+				newSnap := release.ObservedToSnapshot(releaseToObservation(rls, snap, v2.ReleaseActionRollback))
 				newSnap.SetTestHooks(snap.GetTestHooks())
 				obj.Status.History[i] = newSnap
 				return

--- a/internal/reconcile/rollback_remediation_test.go
+++ b/internal/reconcile/rollback_remediation_test.go
@@ -119,7 +119,7 @@ func TestRollbackRemediation_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[2])),
+					observeReleaseWithAction(releases[2], v2.ReleaseActionRollback),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
@@ -335,7 +335,7 @@ func TestRollbackRemediation_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[2])),
+					observeReleaseWithAction(releases[2], v2.ReleaseActionRollback),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
@@ -618,7 +618,9 @@ func Test_observeRollback(t *testing.T) {
 			Version:   previous.Version,
 			Status:    helmreleasecommon.StatusSuperseded,
 		})
-		expect := release.ObservedToSnapshot(release.ObserveRelease(rls))
+		obs := release.ObserveRelease(rls)
+		obs.Action = v2.ReleaseActionRollback
+		expect := release.ObservedToSnapshot(obs)
 
 		observeRollback(obj)(rls)
 		g.Expect(obj.Status.History).To(testutil.Equal(v2.Snapshots{
@@ -662,7 +664,9 @@ func Test_observeRollback(t *testing.T) {
 			Version:   previous.Version,
 			Status:    helmreleasecommon.StatusSuperseded,
 		})
-		expect := release.ObservedToSnapshot(release.ObserveRelease(rls))
+		obs := release.ObserveRelease(rls)
+		obs.Action = v2.ReleaseActionRollback
+		expect := release.ObservedToSnapshot(obs)
 		expect.SetTestHooks(previous.GetTestHooks())
 
 		observeRollback(obj)(rls)
@@ -706,6 +710,7 @@ func Test_observeRollback(t *testing.T) {
 		})
 		obs := release.ObserveRelease(rls)
 		obs.OCIDigest = "sha256:fcdc2b0de1581a3633ada4afee3f918f6eaa5b5ab38c3fef03d5b48d3f85d9f6"
+		obs.Action = v2.ReleaseActionRollback
 		expect := release.ObservedToSnapshot(obs)
 
 		observeRollback(obj)(rls)

--- a/internal/reconcile/suite_test.go
+++ b/internal/reconcile/suite_test.go
@@ -44,6 +44,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	v2 "github.com/fluxcd/helm-controller/api/v2"
+	"github.com/fluxcd/helm-controller/internal/release"
 )
 
 const testFieldManager = "helm-controller"
@@ -162,4 +163,12 @@ func storeHistory(store *helmstorage.Storage, releaseName string) ([]*helmreleas
 		history = append(history, r.(*helmrelease.Release))
 	}
 	return history, nil
+}
+
+// observeReleaseWithAction creates a Snapshot from a release with the given
+// action set. This is a test helper to simplify constructing expected snapshots.
+func observeReleaseWithAction(rls *helmrelease.Release, action v2.ReleaseAction) *v2.Snapshot {
+	obs := release.ObserveRelease(rls)
+	obs.Action = action
+	return release.ObservedToSnapshot(obs)
 }

--- a/internal/reconcile/test.go
+++ b/internal/reconcile/test.go
@@ -204,7 +204,7 @@ func observeTest(obj *v2.HelmRelease) storage.ObserveFunc {
 
 		// Update the latest snapshot with the test result.
 		latest := obj.Status.History.Latest()
-		tested := release.ObservedToSnapshot(releaseToObservation(rls, latest))
+		tested := release.ObservedToSnapshot(releaseToObservation(rls, latest, latest.GetAction()))
 		tested.SetTestHooks(release.TestHooksFromRelease(rls))
 		obj.Status.History[0] = tested
 	}

--- a/internal/reconcile/test_test.go
+++ b/internal/reconcile/test_test.go
@@ -410,6 +410,31 @@ func Test_observeTest(t *testing.T) {
 		}))
 	})
 
+	t.Run("test with current preserves action", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			Status: v2.HelmReleaseStatus{
+				History: v2.Snapshots{
+					&v2.Snapshot{
+						Name:      mockReleaseName,
+						Namespace: mockReleaseNamespace,
+						Version:   1,
+						Action:    v2.ReleaseActionInstall,
+					},
+				},
+			},
+		}
+		rls := testutil.BuildRelease(&helmrelease.MockReleaseOptions{
+			Name:      mockReleaseName,
+			Namespace: mockReleaseNamespace,
+			Version:   1,
+		}, testutil.ReleaseWithHooks(testHookFixtures))
+
+		observeTest(obj)(rls)
+		g.Expect(obj.Status.History.Latest().Action).To(Equal(v2.ReleaseActionInstall))
+	})
+
 	t.Run("test targeting different version than latest", func(t *testing.T) {
 		g := NewWithT(t)
 

--- a/internal/reconcile/uninstall_remediation.go
+++ b/internal/reconcile/uninstall_remediation.go
@@ -81,7 +81,7 @@ func (r *UninstallRemediation) Reconcile(ctx context.Context, req *Request) erro
 	var (
 		cur    = req.Object.Status.History.Latest().DeepCopy()
 		logBuf = action.NewDebugLogBuffer(ctx)
-		cfg    = r.configFactory.Build(logBuf, observeUninstall(req.Object))
+		cfg    = r.configFactory.Build(logBuf, observeUninstall(req.Object, v2.ReleaseActionUninstallRemediation))
 	)
 
 	// Require current to run uninstall.

--- a/internal/reconcile/uninstall_remediation_test.go
+++ b/internal/reconcile/uninstall_remediation_test.go
@@ -114,7 +114,7 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionUninstallRemediation),
 				}
 			},
 		},
@@ -149,7 +149,7 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionUninstallRemediation),
 				}
 			},
 			expectFailures: 1,
@@ -238,7 +238,7 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionUninstallRemediation),
 				}
 			},
 			expectFailures: 1,
@@ -335,7 +335,7 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
+					observeReleaseWithAction(releases[0], v2.ReleaseActionUninstallRemediation),
 				}
 			},
 		},

--- a/internal/reconcile/unlock.go
+++ b/internal/reconcile/unlock.go
@@ -160,7 +160,7 @@ func observeUnlock(obj *v2.HelmRelease) storage.ObserveFunc {
 		for i := range obj.Status.History {
 			snap := obj.Status.History[i]
 			if snap.Targets(rls.Name, rls.Namespace, rls.Version) {
-				obj.Status.History[i] = release.ObservedToSnapshot(releaseToObservation(rls, snap))
+				obj.Status.History[i] = release.ObservedToSnapshot(releaseToObservation(rls, snap, snap.GetAction()))
 				return
 			}
 		}

--- a/internal/reconcile/unlock_test.go
+++ b/internal/reconcile/unlock_test.go
@@ -613,6 +613,33 @@ func Test_observeUnlock(t *testing.T) {
 		}))
 	})
 
+	t.Run("unlock preserves action", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			Status: v2.HelmReleaseStatus{
+				History: v2.Snapshots{
+					{
+						Name:      mockReleaseName,
+						Namespace: mockReleaseNamespace,
+						Version:   1,
+						Status:    helmreleasecommon.StatusPendingRollback.String(),
+						Action:    v2.ReleaseActionUpgrade,
+					},
+				},
+			},
+		}
+		rls := helmrelease.Mock(&helmrelease.MockReleaseOptions{
+			Name:      mockReleaseName,
+			Namespace: mockReleaseNamespace,
+			Version:   1,
+			Status:    helmreleasecommon.StatusFailed,
+		})
+		observeUnlock(obj)(rls)
+
+		g.Expect(obj.Status.History.Latest().Action).To(Equal(v2.ReleaseActionUpgrade))
+	})
+
 	t.Run("unlock without current", func(t *testing.T) {
 		g := NewWithT(t)
 

--- a/internal/reconcile/upgrade.go
+++ b/internal/reconcile/upgrade.go
@@ -87,7 +87,9 @@ func (r *Upgrade) Reconcile(ctx context.Context, req *Request) error {
 	req.Object.Status.LastAttemptedReleaseActionDuration = &metav1.Duration{Duration: time.Since(startTime)}
 
 	// Record the history of releases observed during the upgrade.
-	obsReleases.recordOnObject(req.Object, mutateOCIDigest)
+	obsReleases.recordOnObject(req.Object,
+		mutateOCIDigest,
+		mutateAction(v2.ReleaseActionUpgrade))
 
 	if err != nil {
 		r.failure(req, logBuf, err)

--- a/internal/reconcile/upgrade_test.go
+++ b/internal/reconcile/upgrade_test.go
@@ -121,7 +121,11 @@ func TestUpgrade_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[1])
+						obs.Action = v2.ReleaseActionUpgrade
+						return release.ObservedToSnapshot(obs)
+					}(),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
 			},
@@ -165,7 +169,11 @@ func TestUpgrade_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[1])
+						obs.Action = v2.ReleaseActionUpgrade
+						return release.ObservedToSnapshot(obs)
+					}(),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
 			},
@@ -249,7 +257,11 @@ func TestUpgrade_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[1])
+						obs.Action = v2.ReleaseActionUpgrade
+						return release.ObservedToSnapshot(obs)
+					}(),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
 			},
@@ -281,7 +293,11 @@ func TestUpgrade_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[1])
+						obs.Action = v2.ReleaseActionUpgrade
+						return release.ObservedToSnapshot(obs)
+					}(),
 				}
 			},
 		},
@@ -326,7 +342,11 @@ func TestUpgrade_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[2])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[2])
+						obs.Action = v2.ReleaseActionUpgrade
+						return release.ObservedToSnapshot(obs)
+					}(),
 					{
 						Name:      mockReleaseName,
 						Namespace: releases[0].Namespace,
@@ -366,7 +386,11 @@ func TestUpgrade_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[1])
+						obs.Action = v2.ReleaseActionUpgrade
+						return release.ObservedToSnapshot(obs)
+					}(),
 				}
 			},
 		},
@@ -398,7 +422,11 @@ func TestUpgrade_Reconcile(t *testing.T) {
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
-					release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+					func() *v2.Snapshot {
+						obs := release.ObserveRelease(releases[1])
+						obs.Action = v2.ReleaseActionUpgrade
+						return release.ObservedToSnapshot(obs)
+					}(),
 					release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 				}
 			},
@@ -540,8 +568,10 @@ func TestUpgrade_Reconcile_withSubchartWithCRDs(t *testing.T) {
 	}
 
 	expectHistory := func(releases []*helmrelease.Release) v2.Snapshots {
+		obs := release.ObserveRelease(releases[1])
+		obs.Action = v2.ReleaseActionUpgrade
 		return v2.Snapshots{
-			release.ObservedToSnapshot(release.ObserveRelease(releases[1])),
+			release.ObservedToSnapshot(obs),
 			release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 		}
 	}

--- a/internal/release/observation.go
+++ b/internal/release/observation.go
@@ -67,6 +67,10 @@ type Observation struct {
 	Version int `json:"version"`
 	// Info provides information about the release.
 	Info helmrelease.Info `json:"info"`
+	// Action is the action that resulted in this observation.
+	// It's not serialized to JSON because it's not needed for
+	// the digest. The action is only tracked for visibility.
+	Action v2.ReleaseAction `json:"-"`
 	// ChartMetadata contains the current Chartfile data of the release.
 	ChartMetadata chart.Metadata `json:"chartMetadata"`
 	// Config is the set of extra Values added to the chart.
@@ -172,6 +176,7 @@ func ObservedToSnapshot(rls Observation) *v2.Snapshot {
 		LastDeployed:  metav1.NewTime(rls.Info.LastDeployed),
 		Deleted:       metav1.NewTime(rls.Info.Deleted),
 		Status:        rls.Info.Status.String(),
+		Action:        rls.Action,
 		OCIDigest:     rls.OCIDigest,
 	}
 }

--- a/internal/release/observation_test.go
+++ b/internal/release/observation_test.go
@@ -314,11 +314,32 @@ func TestObservedToSnapshot(t *testing.T) {
 	g.Expect(obs.Info.LastDeployed.Equal(got.LastDeployed.Time)).To(BeTrue())
 	g.Expect(obs.Info.Deleted.Equal(got.Deleted.Time)).To(BeTrue())
 
+	g.Expect(got.Action).To(BeEmpty())
+
 	g.Expect(got.Digest).ToNot(BeEmpty())
 	g.Expect(digest.Digest(got.Digest).Validate()).To(Succeed())
 
 	g.Expect(got.ConfigDigest).ToNot(BeEmpty())
 	g.Expect(digest.Digest(got.ConfigDigest).Validate()).To(Succeed())
+}
+
+func TestObservedToSnapshot_WithAction(t *testing.T) {
+	g := NewWithT(t)
+
+	obs := ObserveRelease(testutil.BuildRelease(&helmrelease.MockReleaseOptions{
+		Name:      "foo",
+		Namespace: "namespace",
+		Version:   1,
+		Chart:     testutil.BuildChart(),
+	}))
+	obs.Action = v2.ReleaseActionInstall
+
+	got := ObservedToSnapshot(obs)
+
+	g.Expect(got.Action).To(Equal(v2.ReleaseActionInstall))
+	g.Expect(got.Name).To(Equal(obs.Name))
+	g.Expect(got.Namespace).To(Equal(obs.Namespace))
+	g.Expect(got.Version).To(Equal(obs.Version))
 }
 
 func TestTestHooksFromRelease(t *testing.T) {


### PR DESCRIPTION
Introduce `.action` field for entries in `.status.history`.