### PR TITLE
Add `DirectSourceFetch` feature gate to bypass cache for source objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,8 @@ require (
 	github.com/fluxcd/pkg/auth v0.38.2
 	github.com/fluxcd/pkg/cache v0.13.0
 	github.com/fluxcd/pkg/chartutil v1.22.0
-	github.com/fluxcd/pkg/runtime v0.100.0
-	github.com/fluxcd/pkg/ssa v0.68.0
+	github.com/fluxcd/pkg/runtime v0.100.1
+	github.com/fluxcd/pkg/ssa v0.67.1
 	github.com/fluxcd/pkg/testserver v0.13.0
 	github.com/fluxcd/source-controller/api v1.7.2
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -160,10 +160,10 @@ github.com/fluxcd/pkg/cache v0.13.0 h1:MqtlgOwIVcGKKgV422e39O+KFSVMWuExKeRaMDBjJ
 github.com/fluxcd/pkg/cache v0.13.0/go.mod h1:0xRZ1hitrIFQ6pl68ke2wZLbIqA2VLzY78HpDo9DVxs=
 github.com/fluxcd/pkg/chartutil v1.22.0 h1:yxhDsAKK0w5Ol4hr1SVnQZI1c83FR9PghVucNEGq4VM=
 github.com/fluxcd/pkg/chartutil v1.22.0/go.mod h1:aw7h410gKTJfk7KchFzv3tZoh6KlwzZFoameLrIEcNg=
-github.com/fluxcd/pkg/runtime v0.100.0 h1:7k2T/zlOLZ+knVr5fGB6cqq3Dr9D1k2jEe6AJo91JlI=
-github.com/fluxcd/pkg/runtime v0.100.0/go.mod h1:SctSsHvFwUfiOVP1zirP6mo7I8wQtXeWVl2lNQWal88=
-github.com/fluxcd/pkg/ssa v0.68.0 h1:hdRFrBJO9dh04200tNJljpi4TOArHC0nq+LUFZxMgKc=
-github.com/fluxcd/pkg/ssa v0.68.0/go.mod h1:PFXVjChubQOiWDxalpwh6PzRsEswGqnKwZB4ScoxDx4=
+github.com/fluxcd/pkg/runtime v0.100.1 h1:UiPmgY8Yv7UF06MT5T8AG9uDGNszm75/DQtK6JEhnrM=
+github.com/fluxcd/pkg/runtime v0.100.1/go.mod h1:SctSsHvFwUfiOVP1zirP6mo7I8wQtXeWVl2lNQWal88=
+github.com/fluxcd/pkg/ssa v0.67.1 h1:wmwrznP+USRUtppKRjAiBx3ayriygRx0IeMdX7z/HaM=
+github.com/fluxcd/pkg/ssa v0.67.1/go.mod h1:PFXVjChubQOiWDxalpwh6PzRsEswGqnKwZB4ScoxDx4=
 github.com/fluxcd/pkg/testserver v0.13.0 h1:xEpBcEYtD7bwvZ+i0ZmChxKkDo/wfQEV3xmnzVybSSg=
 github.com/fluxcd/pkg/testserver v0.13.0/go.mod h1:akRYv3FLQUsme15na9ihECRG6hBuqni4XEY9W8kzs8E=
 github.com/fluxcd/source-controller/api v1.7.2 h1:/lg/xoyRjxwdhHKqjTxQS2o1cp+DMKJ8W4rpm+ZLemQ=

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -25,13 +25,6 @@ import (
 )
 
 const (
-	// CacheSecretsAndConfigMaps configures the caching of Secrets and ConfigMaps
-	// by the controller-runtime client.
-	//
-	// When enabled, it will cache both object types, resulting in increased memory
-	// usage and cluster-wide RBAC permissions (list and watch).
-	CacheSecretsAndConfigMaps = "CacheSecretsAndConfigMaps"
-
 	// DetectDrift configures the detection of cluster state drift compared to
 	// the desired state as described in the manifest of the Helm release
 	// storage object.
@@ -72,14 +65,6 @@ const (
 	// append the digest to the chart version in Chart.yaml.
 	DisableChartDigestTracking = "DisableChartDigestTracking"
 
-	// AdditiveCELDependencyCheck controls whether the CEL dependency check
-	// should be additive, meaning that the built-in readiness check will
-	// be added to the user-defined CEL expressions.
-	AdditiveCELDependencyCheck = "AdditiveCELDependencyCheck"
-
-	// ExternalArtifact controls whether the ExternalArtifact source type is enabled.
-	ExternalArtifact = "ExternalArtifact"
-
 	// UseHelm3Defaults makes the controller use the Helm 3 default behaviors
 	// when defaults are used.
 	UseHelm3Defaults = "UseHelm3Defaults"
@@ -99,7 +84,7 @@ const (
 var features = map[string]bool{
 	// CacheSecretsAndConfigMaps
 	// opt-in from v0.28
-	CacheSecretsAndConfigMaps: false,
+	controller.FeatureGateCacheSecretsAndConfigMaps: false,
 	// DetectDrift
 	// deprecated in v0.37.0
 	DetectDrift: false,
@@ -120,13 +105,16 @@ var features = map[string]bool{
 	DisableChartDigestTracking: false,
 	// AdditiveCELDependencyCheck
 	// opt-in from v1.4.0
-	AdditiveCELDependencyCheck: false,
+	controller.FeatureGateAdditiveCELDependencyCheck: false,
 	// ExternalArtifact
 	// opt-in from v1.4.0
-	ExternalArtifact: false,
+	controller.FeatureGateExternalArtifact: false,
 	// DisableConfigWatchers
 	// opt-in from v1.4.4
 	controller.FeatureGateDisableConfigWatchers: false,
+	// DirectSourceFetch
+	// opt-in from v1.5.0
+	controller.FeatureGateDirectSourceFetch: false,
 	// UseHelm3Defaults
 	// opt-in from v1.5.0
 	UseHelm3Defaults: false,

--- a/main.go
+++ b/main.go
@@ -217,9 +217,9 @@ func main() {
 	}
 
 	var disableCacheFor []ctrlclient.Object
-	shouldCache, err := features.Enabled(features.CacheSecretsAndConfigMaps)
+	shouldCache, err := features.Enabled(helper.FeatureGateCacheSecretsAndConfigMaps)
 	if err != nil {
-		setupLog.Error(err, "unable to check feature gate CacheSecretsAndConfigMaps")
+		setupLog.Error(err, "unable to check feature gate "+helper.FeatureGateCacheSecretsAndConfigMaps)
 		os.Exit(1)
 	}
 	if !shouldCache {
@@ -237,9 +237,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	additiveCELDependencyCheck, err := features.Enabled(features.AdditiveCELDependencyCheck)
+	additiveCELDependencyCheck, err := features.Enabled(helper.FeatureGateAdditiveCELDependencyCheck)
 	if err != nil {
-		setupLog.Error(err, "unable to check feature gate "+features.AdditiveCELDependencyCheck)
+		setupLog.Error(err, "unable to check feature gate "+helper.FeatureGateAdditiveCELDependencyCheck)
 		os.Exit(1)
 	}
 
@@ -348,10 +348,19 @@ func main() {
 		}
 	}
 
-	allowExternalArtifact, err := features.Enabled(features.ExternalArtifact)
+	allowExternalArtifact, err := features.Enabled(helper.FeatureGateExternalArtifact)
 	if err != nil {
-		setupLog.Error(err, "unable to check feature gate "+features.ExternalArtifact)
+		setupLog.Error(err, "unable to check feature gate "+helper.FeatureGateExternalArtifact)
 		os.Exit(1)
+	}
+
+	directSourceFetch, err := features.Enabled(helper.FeatureGateDirectSourceFetch)
+	if err != nil {
+		setupLog.Error(err, "unable to check feature gate "+helper.FeatureGateDirectSourceFetch)
+		os.Exit(1)
+	}
+	if directSourceFetch {
+		setupLog.Info("DirectSourceFetch feature gate is enabled, source objects will be fetched directly from the API server")
 	}
 
 	disableConfigWatchers, err := features.Enabled(helper.FeatureGateDisableConfigWatchers)
@@ -372,6 +381,7 @@ func main() {
 		FieldManager:               controllerName,
 		DisableChartDigestTracking: disableChartDigestTracking,
 		AdditiveCELDependencyCheck: additiveCELDependencyCheck,
+		DirectSourceFetch:          directSourceFetch,
 		TokenCache:                 tokenCache,
 		DependencyRequeueInterval:  requeueDependency,
 		ArtifactFetchRetries:       httpRetry,


### PR DESCRIPTION
This feature gate enables fetching source objects directly from the API server using APIReader, bypassing the controller's cache. This can be useful when immediate consistency is required for source object reads.

When enabled via --feature-gates=DirectSourceFetch=true:

Source objects are fetched using r.APIReader instead of r.Client A log message is emitted at startup indicating the feature is active Changes:

Add DirectSourceFetch field to HelmReleaseReconciler struct Update getSource() to use APIReader when feature is enabled Register feature gate with default value false (opt-in) Add unit tests
Update pkg/runtime dependency to v0.100.1

Part of : https://github.com/fluxcd/kustomize-controller/issues/1583