### PR TITLE
Fix postRenderers not causing new upgrade when applied during ongoing upgrade

### DIFF
--- a/internal/reconcile/atomic_release_test.go
+++ b/internal/reconcile/atomic_release_test.go
@@ -1376,6 +1376,7 @@ func TestAtomicRelease_Reconcile_PostRenderers_Scenarios(t *testing.T) {
 			},
 			status: func(releases []*helmrelease.Release) v2.HelmReleaseStatus {
 				return v2.HelmReleaseStatus{
+					ObservedGeneration: 2, // Matches obj.Generation to skip the digest check.
 					History: v2.Snapshots{
 						release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 					},
@@ -1383,7 +1384,7 @@ func TestAtomicRelease_Reconcile_PostRenderers_Scenarios(t *testing.T) {
 						{
 							Type:               meta.ReadyCondition,
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 2, // This is used to set processed config generation.
+							ObservedGeneration: 2,
 						},
 					},
 					ObservedPostRenderersDigest: postrender.Digest(digest.Canonical, postRenderers).String(),
@@ -2357,6 +2358,7 @@ func TestAtomicRelease_Reconcile_CommonMetadata_Scenarios(t *testing.T) {
 			},
 			status: func(releases []*helmrelease.Release) v2.HelmReleaseStatus {
 				return v2.HelmReleaseStatus{
+					ObservedGeneration: 2, // Matches obj.Generation to skip the digest check.
 					History: v2.Snapshots{
 						release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 					},
@@ -2364,7 +2366,7 @@ func TestAtomicRelease_Reconcile_CommonMetadata_Scenarios(t *testing.T) {
 						{
 							Type:               meta.ReadyCondition,
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 2, // This is used to set processed config generation.
+							ObservedGeneration: 2,
 						},
 					},
 					ObservedPostRenderersDigest: postrender.CommonMetadataDigest(digest.Canonical, commonMetadata).String(),

--- a/internal/reconcile/state_test.go
+++ b/internal/reconcile/state_test.go
@@ -508,17 +508,11 @@ func Test_DetermineReleaseState(t *testing.T) {
 			},
 			status: func(releases []*helmrelease.Release) v2.HelmReleaseStatus {
 				return v2.HelmReleaseStatus{
+					ObservedGeneration: 2,
 					History: v2.Snapshots{
 						release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 					},
 					ObservedPostRenderersDigest: postrender.Digest(digest.Canonical, postRenderers).String(),
-					Conditions: []metav1.Condition{
-						{
-							Type:               meta.ReadyCondition,
-							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 2,
-						},
-					},
 				}
 			},
 			chart:  testutil.BuildChart(),
@@ -578,17 +572,11 @@ func Test_DetermineReleaseState(t *testing.T) {
 			},
 			status: func(releases []*helmrelease.Release) v2.HelmReleaseStatus {
 				return v2.HelmReleaseStatus{
+					ObservedGeneration: 2,
 					History: v2.Snapshots{
 						release.ObservedToSnapshot(release.ObserveRelease(releases[0])),
 					},
 					ObservedCommonMetadataDigest: postrender.CommonMetadataDigest(digest.Canonical, commonMetadata).String(),
-					Conditions: []metav1.Condition{
-						{
-							Type:               meta.ReadyCondition,
-							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 2,
-						},
-					},
 				}
 			},
 			chart:  testutil.BuildChart(),


### PR DESCRIPTION
Fixes a race condition where changing `postRenderers` or `commonMetadata` while the controller is performing an upgrade does not trigger a second upgrade to apply the new configuration.

**Root cause:** The generation guard in `DetermineReleaseState` compared `req.Object.Generation` against the Ready condition's `ObservedGeneration` to decide whether to check for digest changes. However, `patchStatusConditions()` re-fetches the object from the API server to resolve conflicts, and `conditions.Set()` always overwrites `ObservedGeneration` with `to.GetGeneration()` — which at that point reflects the latest generation (including the mid-reconciliation spec change). This causes the guard to see the generation as already processed, skipping the digest comparison entirely on the next reconciliation.

**Fix:**
- Use the top-level `status.observedGeneration` for the generation guard instead of the Ready condition's `ObservedGeneration`. The top-level field is set by the outer defer using the in-memory generation snapshot and is not affected by the patch helper's conflict resolution.
- Move the `ObservedPostRenderersDigest` and `ObservedCommonMetadataDigest` updates into `summarize()`, which is called after every action (install, upgrade, test, rollback, etc.), ensuring the digests are always kept in sync.