### PR TITLE
Route chart name changes through upgrade instead of uninstall/reinstall

### DIFF
--- a/internal/action/verify.go
+++ b/internal/action/verify.go
@@ -67,8 +67,6 @@ func ReleaseTargetChanged(obj *v2.HelmRelease, chartName string) (string, bool) 
 		return targetReleaseNamespace, true
 	case release.ShortenName(obj.GetReleaseName()) != cur.Name:
 		return targetReleaseName, true
-	case chartName != cur.ChartName:
-		return targetChartName, true
 	default:
 		return "", false
 	}

--- a/internal/action/verify_test.go
+++ b/internal/action/verify_test.go
@@ -167,8 +167,8 @@ func TestReleaseTargetChanged(t *testing.T) {
 				},
 				StorageNamespace: defaultNamespace,
 			},
-			wantReason: targetChartName,
-			want:       true,
+			wantReason: "",
+			want:       false,
 		},
 		{
 			name:      "matching shortened release name",


### PR DESCRIPTION
## Summary

- Chart name changes in a HelmRelease currently trigger a full uninstall/reinstall cycle via `ReleaseTargetChanged()`, causing unnecessary downtime by deleting all resources before recreating them
- Unlike release name or namespace changes, a chart name change does not affect the Helm storage key — `helm upgrade` correctly diffs old and new manifests, removing resources no longer in the new chart
- `VerifyRelease()` already detects chart name changes via `ErrChartChanged`, routing them to `ReleaseStatusOutOfSync` and the upgrade path — so the fallback behavior is already in place

## Test plan

- [x] Updated `TestReleaseTargetChanged` to assert chart name change returns `false`
- [x] Full test suite passes (`make test`)
- [ ] Integration test with a live cluster: change chart name on an existing HelmRelease and verify the controller performs an upgrade (not uninstall/reinstall) and existing resources are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)