### PR TITLE
Add configurable HTTP timeout for artifact fetching

### DIFF
--- a/internal/controller/helmrelease_controller.go
+++ b/internal/controller/helmrelease_controller.go
@@ -104,6 +104,7 @@ type HelmReleaseReconciler struct {
 
 	DependencyRequeueInterval time.Duration
 	ArtifactFetchRetries      int
+	ArtifactFetchTimeout      time.Duration
 
 	// Feature gates
 
@@ -325,7 +326,7 @@ func (r *HelmReleaseReconciler) reconcileRelease(ctx context.Context,
 	}
 
 	// Load chart from artifact.
-	loadedChart, err := loader.SecureLoadChartFromURL(loader.NewRetryableHTTPClient(ctx, r.ArtifactFetchRetries), source.GetArtifact().URL, source.GetArtifact().Digest)
+	loadedChart, err := loader.SecureLoadChartFromURL(loader.NewRetryableHTTPClient(ctx, r.ArtifactFetchRetries, r.ArtifactFetchTimeout), source.GetArtifact().URL, source.GetArtifact().Digest)
 	if err != nil {
 		if errors.Is(err, loader.ErrFileNotFound) {
 			msg := fmt.Sprintf("Source not ready: artifact not found. Retrying in %s", r.DependencyRequeueInterval.String())

--- a/internal/controller_test/suite_test.go
+++ b/internal/controller_test/suite_test.go
@@ -184,6 +184,7 @@ func StartController() error {
 		FieldManager:               controllerName,
 		DependencyRequeueInterval:  5 * time.Second,
 		ArtifactFetchRetries:       1,
+		ArtifactFetchTimeout:       30 * time.Second,
 		DefaultServiceAccount:      "",
 		DisableChartDigestTracking: false,
 		AdditiveCELDependencyCheck: false,

--- a/internal/loader/client.go
+++ b/internal/loader/client.go
@@ -27,12 +27,14 @@ import (
 
 // NewRetryableHTTPClient returns a new retrying HTTP client for loading
 // artifacts. The client will retry up to the given number of times before
-// giving up. The context is used to log errors.
-func NewRetryableHTTPClient(ctx context.Context, retries int) *retryablehttp.Client {
+// giving up. The context is used to log errors. The timeout is the maximum
+// duration for HTTP requests.
+func NewRetryableHTTPClient(ctx context.Context, retries int, timeout time.Duration) *retryablehttp.Client {
 	httpClient := retryablehttp.NewClient()
 	httpClient.RetryWaitMin = 5 * time.Second
 	httpClient.RetryWaitMax = 30 * time.Second
 	httpClient.RetryMax = retries
+	httpClient.HTTPClient.Timeout = timeout
 	httpClient.Logger = newLoggerForContext(ctx)
 	return httpClient
 }

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ func main() {
 		requeueDependency               time.Duration
 		gracefulShutdownTimeout         time.Duration
 		httpRetry                       int
+		httpTimeout                     time.Duration
 		clientOptions                   client.Options
 		kubeConfigOpts                  client.KubeConfigOptions
 		featureGates                    feathelper.FeatureGates
@@ -124,6 +125,8 @@ func main() {
 		"The duration given to the reconciler to finish before forcibly stopping.")
 	flag.IntVar(&httpRetry, "http-retry", 9,
 		"The maximum number of retries when failing to fetch artifacts over HTTP.")
+	flag.DurationVar(&httpTimeout, "http-timeout", 30*time.Second,
+		"The timeout for HTTP requests when fetching artifacts.")
 	flag.StringVar(&intkube.DefaultServiceAccountName, auth.ControllerFlagDefaultServiceAccount, "",
 		"Default service account used for impersonation.")
 	flag.StringVar(&defaultKubeConfigServiceAccount, auth.ControllerFlagDefaultKubeConfigServiceAccount, "",
@@ -392,6 +395,7 @@ func main() {
 		TokenCache:                 tokenCache,
 		DependencyRequeueInterval:  requeueDependency,
 		ArtifactFetchRetries:       httpRetry,
+		ArtifactFetchTimeout:       httpTimeout,
 		AllowExternalArtifact:      allowExternalArtifact,
 		DisallowedFieldManagers:    disallowedFieldManagers,
 	}).SetupWithManager(ctx, mgr, controller.HelmReleaseReconcilerOptions{


### PR DESCRIPTION
**Summary**

This PR introduces a configurable timeout for HTTP requests used in artifact fetching to prevent indefinite blocking when the upstream source becomes unresponsive.

**Problem**

Currently, the retryable HTTP client does not set a timeout, allowing requests to block indefinitely if the underlying TCP connection remains open without a response.

Since retries are only triggered after a request fails, indefinitely blocking requests prevent retries from being invoked, leading to worker starvation and stalled reconciliations.

**Root Cause**

NewRetryableHTTPClient configures retry behavior but does not set HTTPClient.Timeout, leaving request duration unbounded.

**Solution**

This PR:
- Introduces a configurable HTTP timeout
- Sets HTTPClient.Timeout on the retryable client
- Adds a CLI flag (--http-timeout) with a default of 30s

**Impact**

This ensures that stalled HTTP requests eventually fail, allowing retries and reconciliation loops to continue instead of blocking indefinitely.

**Notes**

- Timeout applies per request attempt; total retry duration is still governed by retry configuration
- Users may need to tune timeout values based on network conditions and artifact size

Fixes #1463 