### PR TITLE
Add post-render strategy support and conditional defaults

### DIFF
--- a/api/v2/helmrelease_types.go
+++ b/api/v2/helmrelease_types.go
@@ -185,6 +185,15 @@ type HelmReleaseSpec struct {
 	// +optional
 	PostRenderers []PostRenderer `json:"postRenderers,omitempty"`
 
+	// PostRenderStrategy defines the strategy for sending hooks to post-renderers.
+	// Valid values are 'nohooks' (hooks not sent to post-renderers, Helm 3 behavior),
+	// 'combined' (hooks and templates sent together, Helm 4 default), and 'separate'
+	// (hooks and templates sent in separate streams, Helm 4.2 opt-in).
+	// Defaults to 'combined', or 'nohooks' when the UseHelm3Defaults feature gate is enabled.
+	// +kubebuilder:validation:Enum=nohooks;combined;separate
+	// +optional
+	PostRenderStrategy PostRenderStrategy `json:"postRenderStrategy,omitempty"`
+
 	// WaitStrategy defines Helm's wait strategy for waiting for applied
 	// resources to become ready.
 	// +optional
@@ -234,6 +243,23 @@ type PostRenderer struct {
 	// +optional
 	Kustomize *Kustomize `json:"kustomize,omitempty"`
 }
+
+// PostRenderStrategy represents the strategy for sending hooks to post-renderers.
+type PostRenderStrategy string
+
+const (
+	// PostRenderStrategyNoHooks is the Helm 3 behavior where hooks are not sent
+	// to post-renderers.
+	PostRenderStrategyNoHooks PostRenderStrategy = "nohooks"
+
+	// PostRenderStrategyCombined is the Helm 4 default behavior where both hooks
+	// and templates are sent to post-renderers in the same stream.
+	PostRenderStrategyCombined PostRenderStrategy = "combined"
+
+	// PostRenderStrategySeparate is the Helm 4.2 opt-in behavior where hooks and
+	// templates are sent to post-renderers in separate streams.
+	PostRenderStrategySeparate PostRenderStrategy = "separate"
+)
 
 // DriftDetectionMode represents the modes in which a controller can detect and
 // handle differences between the manifest in the Helm storage and the resources
@@ -469,6 +495,11 @@ func (in *HelmRelease) GetWaitStrategy() WaitStrategyName {
 		return in.Spec.WaitStrategy.Name
 	}
 	return ""
+}
+
+// GetPostRenderStrategy returns the post-render strategy for the Helm actions.
+func (in *HelmRelease) GetPostRenderStrategy() PostRenderStrategy {
+	return in.Spec.PostRenderStrategy
 }
 
 // Remediation defines a consistent interface for InstallRemediation and

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -621,6 +621,18 @@ spec:
 
                   If not set, it defaults to true.
                 type: boolean
+              postRenderStrategy:
+                description: |-
+                  PostRenderStrategy defines the strategy for sending hooks to post-renderers.
+                  Valid values are 'nohooks' (hooks not sent to post-renderers, Helm 3 behavior),
+                  'combined' (hooks and templates sent together, Helm 4 default), and 'separate'
+                  (hooks and templates sent in separate streams, Helm 4.2 opt-in).
+                  Defaults to 'combined', or 'nohooks' when the UseHelm3Defaults feature gate is enabled.
+                enum:
+                - nohooks
+                - combined
+                - separate
+                type: string
               postRenderers:
                 description: |-
                   PostRenderers holds an array of Helm PostRenderers, which will be applied in order

--- a/docs/api/v2/helm.md
+++ b/docs/api/v2/helm.md
@@ -407,6 +407,24 @@ of their definition.</p>
 </tr>
 <tr>
 <td>
+<code>postRenderStrategy</code><br>
+<em>
+<a href="#helm.toolkit.fluxcd.io/v2.PostRenderStrategy">
+PostRenderStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PostRenderStrategy defines the strategy for sending hooks to post-renderers.
+Valid values are &lsquo;nohooks&rsquo; (hooks not sent to post-renderers, Helm 3 behavior),
+&lsquo;combined&rsquo; (hooks and templates sent together, Helm 4 default), and &lsquo;separate&rsquo;
+(hooks and templates sent in separate streams, Helm 4.2 opt-in).
+Defaults to &lsquo;combined&rsquo;, or &lsquo;nohooks&rsquo; when the UseHelm3Defaults feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>waitStrategy</code><br>
 <em>
 <a href="#helm.toolkit.fluxcd.io/v2.WaitStrategy">
@@ -1575,6 +1593,24 @@ of their definition.</p>
 </tr>
 <tr>
 <td>
+<code>postRenderStrategy</code><br>
+<em>
+<a href="#helm.toolkit.fluxcd.io/v2.PostRenderStrategy">
+PostRenderStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PostRenderStrategy defines the strategy for sending hooks to post-renderers.
+Valid values are &lsquo;nohooks&rsquo; (hooks not sent to post-renderers, Helm 3 behavior),
+&lsquo;combined&rsquo; (hooks and templates sent together, Helm 4 default), and &lsquo;separate&rsquo;
+(hooks and templates sent in separate streams, Helm 4.2 opt-in).
+Defaults to &lsquo;combined&rsquo;, or &lsquo;nohooks&rsquo; when the UseHelm3Defaults feature gate is enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>waitStrategy</code><br>
 <em>
 <a href="#helm.toolkit.fluxcd.io/v2.WaitStrategy">
@@ -2370,6 +2406,13 @@ patch, but this operator is simpler to specify.</p>
 </table>
 </div>
 </div>
+<h3 id="helm.toolkit.fluxcd.io/v2.PostRenderStrategy">PostRenderStrategy
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec">HelmReleaseSpec</a>)
+</p>
+<p>PostRenderStrategy represents the strategy for sending hooks to post-renderers.</p>
 <h3 id="helm.toolkit.fluxcd.io/v2.PostRenderer">PostRenderer
 </h3>
 <p>

--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -526,6 +526,22 @@ spec:
     replicaCount: 2
 ```
 
+### Post-render strategy
+
+`.spec.postRenderStrategy` is an optional field to configure the strategy for sending
+hooks to post-renderers. Valid values are:
+
+- `nohooks`: Hooks are not sent to post-renderers (Helm 3 behavior).
+- `combined`: Hooks and templates are sent together to post-renderers in the same stream (Helm 4 default).
+- `separate`: Hooks and templates are sent to post-renderers in separate streams (Helm 4.2 opt-in).
+
+Defaults to `combined`, or `nohooks` when the `UseHelm3Defaults` feature gate is enabled.
+
+```yaml
+spec:
+  postRenderStrategy: combined
+```
+
 ### Install configuration
 
 `.spec.install` is an optional field to specify the configuration for the

--- a/internal/action/install.go
+++ b/internal/action/install.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"helm.sh/helm/v4/pkg/action"
 	helmaction "helm.sh/helm/v4/pkg/action"
 	helmchartutil "helm.sh/helm/v4/pkg/chart/common"
 	helmchart "helm.sh/helm/v4/pkg/chart/v2"
@@ -109,7 +108,7 @@ func newInstall(config *helmaction.Configuration, obj *v2.HelmRelease, opts []In
 	}
 
 	install.PostRenderer = postrender.BuildPostRenderers(obj)
-	install.PostRenderStrategy = action.PostRenderStrategyNoHooks
+	install.PostRenderStrategy = toHelmPostRenderStrategy(obj.GetPostRenderStrategy())
 
 	for _, opt := range opts {
 		opt(install)

--- a/internal/action/install_test.go
+++ b/internal/action/install_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"helm.sh/helm/v4/pkg/action"
 	helmaction "helm.sh/helm/v4/pkg/action"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -207,5 +208,101 @@ func Test_newInstall(t *testing.T) {
 		got := newInstall(&helmaction.Configuration{}, obj, nil)
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(got.ServerSideApply).To(BeFalse())
+	})
+
+	t.Run("post render strategy defaults to combined with Helm4 defaults", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Save and restore UseHelm3Defaults
+		oldUseHelm3Defaults := UseHelm3Defaults
+		t.Cleanup(func() { UseHelm3Defaults = oldUseHelm3Defaults })
+		UseHelm3Defaults = false
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "install",
+				Namespace: "install-ns",
+			},
+			Spec: v2.HelmReleaseSpec{},
+		}
+
+		got := newInstall(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategyCombined))
+	})
+
+	t.Run("post render strategy defaults to nohooks with UseHelm3Defaults", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Save and restore UseHelm3Defaults
+		oldUseHelm3Defaults := UseHelm3Defaults
+		t.Cleanup(func() { UseHelm3Defaults = oldUseHelm3Defaults })
+		UseHelm3Defaults = true
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "install",
+				Namespace: "install-ns",
+			},
+			Spec: v2.HelmReleaseSpec{},
+		}
+
+		got := newInstall(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategyNoHooks))
+	})
+
+	t.Run("post render strategy combined", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "install",
+				Namespace: "install-ns",
+			},
+			Spec: v2.HelmReleaseSpec{
+				PostRenderStrategy: v2.PostRenderStrategyCombined,
+			},
+		}
+
+		got := newInstall(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategyCombined))
+	})
+
+	t.Run("post render strategy separate", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "install",
+				Namespace: "install-ns",
+			},
+			Spec: v2.HelmReleaseSpec{
+				PostRenderStrategy: v2.PostRenderStrategySeparate,
+			},
+		}
+
+		got := newInstall(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategySeparate))
+	})
+
+	t.Run("post render strategy nohooks", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "install",
+				Namespace: "install-ns",
+			},
+			Spec: v2.HelmReleaseSpec{
+				PostRenderStrategy: v2.PostRenderStrategyNoHooks,
+			},
+		}
+
+		got := newInstall(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategyNoHooks))
 	})
 }

--- a/internal/action/post_render.go
+++ b/internal/action/post_render.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"helm.sh/helm/v4/pkg/action"
+
+	v2 "github.com/fluxcd/helm-controller/api/v2"
+)
+
+// toHelmPostRenderStrategy converts the API PostRenderStrategy to the Helm SDK value.
+// If the strategy is not set, it defaults to PostRenderStrategyCombined (Helm 4 default),
+// or PostRenderStrategyNoHooks when UseHelm3Defaults is enabled.
+func toHelmPostRenderStrategy(strategy v2.PostRenderStrategy) action.PostRenderStrategy {
+	if strategy == "" {
+		if UseHelm3Defaults {
+			return action.PostRenderStrategyNoHooks
+		}
+		return action.PostRenderStrategyCombined
+	}
+	return action.PostRenderStrategy(strategy)
+}

--- a/internal/action/upgrade.go
+++ b/internal/action/upgrade.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 
-	"helm.sh/helm/v4/pkg/action"
 	helmaction "helm.sh/helm/v4/pkg/action"
 	helmchartutil "helm.sh/helm/v4/pkg/chart/common"
 	helmchart "helm.sh/helm/v4/pkg/chart/v2"
@@ -127,7 +126,7 @@ func newUpgrade(config *helmaction.Configuration, obj *v2.HelmRelease, opts []Up
 	}
 
 	upgrade.PostRenderer = postrender.BuildPostRenderers(obj)
-	upgrade.PostRenderStrategy = action.PostRenderStrategyNoHooks
+	upgrade.PostRenderStrategy = toHelmPostRenderStrategy(obj.GetPostRenderStrategy())
 
 	for _, opt := range opts {
 		opt(upgrade)

--- a/internal/action/upgrade_test.go
+++ b/internal/action/upgrade_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"helm.sh/helm/v4/pkg/action"
 	helmaction "helm.sh/helm/v4/pkg/action"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -168,5 +169,101 @@ func Test_newUpgrade(t *testing.T) {
 		got = newUpgrade(&helmaction.Configuration{}, obj, nil)
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(got.ServerSideApply).To(Equal("false"))
+	})
+
+	t.Run("post render strategy defaults to combined with Helm4 defaults", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Save and restore UseHelm3Defaults
+		oldUseHelm3Defaults := UseHelm3Defaults
+		t.Cleanup(func() { UseHelm3Defaults = oldUseHelm3Defaults })
+		UseHelm3Defaults = false
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "upgrade",
+				Namespace: "upgrade-ns",
+			},
+			Spec: v2.HelmReleaseSpec{},
+		}
+
+		got := newUpgrade(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategyCombined))
+	})
+
+	t.Run("post render strategy defaults to nohooks with UseHelm3Defaults", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Save and restore UseHelm3Defaults
+		oldUseHelm3Defaults := UseHelm3Defaults
+		t.Cleanup(func() { UseHelm3Defaults = oldUseHelm3Defaults })
+		UseHelm3Defaults = true
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "upgrade",
+				Namespace: "upgrade-ns",
+			},
+			Spec: v2.HelmReleaseSpec{},
+		}
+
+		got := newUpgrade(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategyNoHooks))
+	})
+
+	t.Run("post render strategy combined", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "upgrade",
+				Namespace: "upgrade-ns",
+			},
+			Spec: v2.HelmReleaseSpec{
+				PostRenderStrategy: v2.PostRenderStrategyCombined,
+			},
+		}
+
+		got := newUpgrade(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategyCombined))
+	})
+
+	t.Run("post render strategy separate", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "upgrade",
+				Namespace: "upgrade-ns",
+			},
+			Spec: v2.HelmReleaseSpec{
+				PostRenderStrategy: v2.PostRenderStrategySeparate,
+			},
+		}
+
+		got := newUpgrade(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategySeparate))
+	})
+
+	t.Run("post render strategy nohooks", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &v2.HelmRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "upgrade",
+				Namespace: "upgrade-ns",
+			},
+			Spec: v2.HelmReleaseSpec{
+				PostRenderStrategy: v2.PostRenderStrategyNoHooks,
+			},
+		}
+
+		got := newUpgrade(&helmaction.Configuration{}, obj, nil)
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.PostRenderStrategy).To(Equal(action.PostRenderStrategyNoHooks))
 	})
 }


### PR DESCRIPTION
Fixes #1469

**⚠️ Breaking change**: From Flux 2.8.0 to 2.8.5 the default was `combined` (Helm 4 breaking change), then in Flux 2.8.6 we fixed the regression (changed the behavior to `nohooks`). In Flux 2.9 (through this PR) we are changing this default back to `combined` for honoring the feature gate `UseHelm3Defaults`, which defaults to the **Helm 4** defaults when the gate is `false`, and to the **Helm 3** defaults when the gate is `true`. We are sustaining our decision to keep aligned with Helm's defaults throughout Flux's and Helm's lives. This commitment implies shipping breaking changes whenever Helm changes default functionality in major versions.

**The behavior can also be pinned to a specific value directly in the `HelmRelease` object through the field introduced in this PR.**

Adds support for Helm's post-render strategies (nohooks, combined, separate) being introduced in Helm 4.2. The new `spec.postRenderStrategy` field allows users to configure how hooks are sent to post-renderers.

**Changes:**
- Add `PostRenderStrategy` enum with values: `nohooks`, `combined`, `separate`
- Add `spec.postRenderStrategy` field to `HelmReleaseSpec`
- Add `toHelmPostRenderStrategy()` mapping function in action package
- Update install and upgrade actions to use the configured strategy
- Add unit tests for default behaviour and all strategy values

**Default behavior:**
- Defaults to `combined` to align with upstream Helm
- Respects `UseHelm3Defaults` feature gate by switching to `nohooks` when enabled