### PR TITLE
Add missing defer summarize(req) in UninstallRemediation

### DIFF
--- a/internal/reconcile/uninstall_remediation.go
+++ b/internal/reconcile/uninstall_remediation.go
@@ -84,6 +84,8 @@ func (r *UninstallRemediation) Reconcile(ctx context.Context, req *Request) erro
 		cfg    = r.configFactory.Build(logBuf, observeUninstall(req.Object, v2.ReleaseActionUninstallRemediation))
 	)
 
+	defer summarize(req)
+
 	// Require current to run uninstall.
 	if cur == nil {
 		return fmt.Errorf("%w: required to uninstall", ErrNoLatest)

--- a/internal/reconcile/uninstall_remediation_test.go
+++ b/internal/reconcile/uninstall_remediation_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
 
 	"github.com/fluxcd/pkg/chartutil"
@@ -111,6 +112,8 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 			expectConditions: []metav1.Condition{
 				*conditions.TrueCondition(v2.RemediatedCondition, v2.UninstallSucceededReason,
 					"succeeded"),
+				*conditions.FalseCondition(meta.ReadyCondition, v2.UninstallSucceededReason,
+					"succeeded"),
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
@@ -144,6 +147,8 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 				}
 			},
 			expectConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, v2.UninstallFailedReason,
+					"context deadline exceeded"),
 				*conditions.FalseCondition(v2.RemediatedCondition, v2.UninstallFailedReason,
 					"context deadline exceeded"),
 			},
@@ -191,6 +196,8 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 				}
 			},
 			expectConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, v2.UninstallFailedReason,
+					"%s", ErrNoStorageUpdate.Error()),
 				*conditions.FalseCondition(v2.RemediatedCondition, v2.UninstallFailedReason,
 					"%s", ErrNoStorageUpdate.Error()),
 			},
@@ -234,7 +241,10 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 				}
 			},
 			expectConditions: []metav1.Condition{
-				*conditions.FalseCondition(v2.RemediatedCondition, v2.UninstallFailedReason, "%s", mockDeleteErr.Error()),
+				*conditions.FalseCondition(meta.ReadyCondition, v2.UninstallFailedReason,
+					"%s", mockDeleteErr.Error()),
+				*conditions.FalseCondition(v2.RemediatedCondition, v2.UninstallFailedReason,
+					"%s", mockDeleteErr.Error()),
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {
 				return v2.Snapshots{
@@ -292,6 +302,8 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 				}
 			},
 			expectConditions: []metav1.Condition{
+				*conditions.FalseCondition(meta.ReadyCondition, v2.UninstallFailedReason,
+					"%s", ErrReleaseMismatch.Error()),
 				*conditions.FalseCondition(v2.RemediatedCondition, v2.UninstallFailedReason,
 					"%s", ErrReleaseMismatch.Error()),
 			},
@@ -331,6 +343,8 @@ func TestUninstallRemediation_Reconcile(t *testing.T) {
 			statusReader: true,
 			expectConditions: []metav1.Condition{
 				*conditions.TrueCondition(v2.RemediatedCondition, v2.UninstallSucceededReason,
+					"succeeded"),
+				*conditions.FalseCondition(meta.ReadyCondition, v2.UninstallSucceededReason,
 					"succeeded"),
 			},
 			expectHistory: func(releases []*helmrelease.Release) v2.Snapshots {


### PR DESCRIPTION
## Description

`UninstallRemediation.Reconcile` is the only action reconciler that does not call `defer summarize(req)`. All six other reconcilers (`Install`, `Upgrade`, `Test`, `Uninstall`, `Unlock`, `RollbackRemediation`) include this call.

Without it, the `Ready` condition is never updated after an uninstall remediation, and `ObservedPostRenderersDigest` / `ObservedCommonMetadataDigest` are not refreshed.

Closes #1488

## Changes

One-line addition: `defer summarize(req)` after the variable block, matching all other reconcilers.

## Verification

- `go build ./...` passes
- `go vet ./...` passes
- Integration tests require etcd (CI)