### PR TITLE
Fix observedReleases.recordOnObject to process all versions

### DIFF
--- a/internal/reconcile/release.go
+++ b/internal/reconcile/release.go
@@ -103,7 +103,7 @@ func (r observedReleases) recordOnObject(obj *v2.HelmRelease, mutators ...mutate
 					newSnap := release.ObservedToSnapshot(obs)
 					newSnap.SetTestHooks(snap.GetTestHooks())
 					obj.Status.History[i] = newSnap
-					return
+					break
 				}
 			}
 		}


### PR DESCRIPTION
## Description

In `observedReleases.recordOnObject`, the `default` case (3+ observed releases) uses `return` instead of `break` in the inner loop. After matching the first secondary version, the function exits entirely, silently dropping any remaining versions.

Closes #1490

## Changes

One-word change: replace `return` with `break` in `release.go:106` so the outer version loop continues.

## Verification

- `go build ./...` passes
- `go vet ./...` passes
- `go test ./internal/release/...` passes
- Integration tests require etcd (CI)