### PR TITLE
docs: document literal field on valuesFrom

### DIFF
--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -487,6 +487,13 @@ An item on the list offers the following subkeys:
   `true`, a not found error for the values reference is ignored, but any
   `valuesKey`, `targetPath` or transient error will still result in a
   reconciliation failure. Defaults to `false` when omitted.
+- `literal` (Optional): When set together with `targetPath`, the referenced
+  value is merged at the target path verbatim, without interpreting Helm's
+  `--set` syntax (commas, brackets, dots, equal signs, etc.). Mirrors the
+  behavior of `helm --set-literal`. Use this to inject arbitrary file content
+  (config files, JSON blobs, multi-line strings containing special characters)
+  through `valuesFrom`. Has no effect when `targetPath` is empty.
+  Defaults to `false` when omitted.
 
 ```yaml
 spec:
@@ -499,6 +506,11 @@ spec:
       valuesKey: crt
       targetPath: tls.crt
       optional: true
+    - kind: ConfigMap
+      name: app-config-source
+      valuesKey: application.yml
+      targetPath: 'externalConfig.application\.yml.content'
+      literal: true
 ```
 
 **Note:** The `targetPath` supports the same formatting as you would supply as
@@ -509,6 +521,11 @@ a list). You can read more about the available formats and limitations in the
 
 For JSON strings, the [limitations are the same as while using `helm`](https://github.com/helm/helm/issues/5618)
 and require you to escape the full JSON string (including `=`, `[`, `,`, `.`).
+
+To skip the `--set`-style parsing entirely and pass the value as a raw string
+(useful for full config files or any content containing `,`, `[`, `]`, `{`,
+`}`, `=`), set `literal: true` together with `targetPath`. This mirrors
+`helm --set-literal`.
 
 To make a HelmRelease react immediately to changes in the referenced Secret
 or ConfigMap see [this](#reacting-immediately-to-configuration-dependencies)


### PR DESCRIPTION
Closes: https://github.com/fluxcd/flux2/issues/2625

Adds the user-facing documentation for the new `literal` field on `valuesFrom` entries.

## Context

The new field has two parts:

1. **OpenAPI schema** in `config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml` — already landed via #1506 (k8s 1.36 / Go 1.26 bump regenerated the CRD and picked up the `Literal` field from the meta package).
2. **Runtime support** in `fluxcd/pkg/chartutil` — in flight as [fluxcd/pkg#1218](https://github.com/fluxcd/pkg/pull/1218). Once that merges and a release is cut, a follow-up here will bump the dependency so helm-controller actually honours the field.

This PR fills in the missing third piece: the user-facing reference in `docs/spec/v2/helmreleases.md`. Until pkg ships, setting `literal: true` is accepted-but-ignored — forward-compatible behaviour.

## Motivation

`valuesFrom` with `targetPath` runs the referenced value through `strvals.ParseInto` — the same parser as `helm --set`. Anything containing `,`, `[`, `]`, `{`, `}` or unescaped `=` is interpreted as Helm-set syntax, so arbitrary file content (Spring `application.yml` with flow sequences, HOCON `application.conf`, JSON blobs, multi-line YAML, …) is misparsed or fails outright. Examples in the wild:

```
error parsing index: strconv.Atoi: parsing " \"prometheus\", \"health\", \"info\" ": invalid syntax
key "efm" has no value (cannot end with ,)
```

The quote-wrap workaround from #298 is impractical when content arrives via Kustomize `configMapGenerator`/`secretGenerator` (raw file → raw bytes in the CM, no opportunity to wrap). Flux's kustomize-controller [disables Kustomize plugins](https://github.com/fluxcd/pkg/blob/main/kustomize/kustomize_generator.go) so a generator/transformer-based wrap is also off the table.

## What's in this PR

- New `literal` (Optional) bullet in the `valuesFrom` subkey list.
- Concrete YAML example using `literal: true` with a kustomize-style raw file payload.
- Short call-out at the bottom of the `valuesFrom` section pointing users to `literal: true` when their content contains `,`, `[`, `]`, `{`, `}`, `=`.

## Resolves

[fluxcd/helm-controller#1317](https://github.com/fluxcd/helm-controller/issues/1317). Addresses parts of #460, #853, [flux2#1756](https://github.com/fluxcd/flux2/issues/1756).