### PR TITLE
Add backport:release/v1.6.x label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -31,3 +31,6 @@
 - name: backport:release/v1.5.x
   description: To be backported to release/v1.5.x
   color: '#ffd700'
+- name: backport:release/v1.6.x
+  description: To be backported to release/v1.6.x
+  color: '#ffd700'


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/5942