### PR TITLE
Add categories to the HelmRelease CRD

### DIFF
--- a/api/v2/helmrelease_types.go
+++ b/api/v2/helmrelease_types.go
@@ -1431,7 +1431,7 @@ const (
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hr
+// +kubebuilder:resource:shortName=hr,categories=all;fluxcd;fluxcd-appliers
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""

--- a/api/v2beta1/helmrelease_types.go
+++ b/api/v2beta1/helmrelease_types.go
@@ -1096,7 +1096,6 @@ const (
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=hr
 // +kubebuilder:skipversion
 
 // HelmRelease is the Schema for the helmreleases API

--- a/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: helm.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-appliers
     kind: HelmRelease
     listKind: HelmReleaseList
     plural: helmreleases


### PR DESCRIPTION
This adds the standard Flux resource categories to the HelmRelease CRD in this
repository so users can list Flux resources with kubectl, for example:

```
kubectl get fluxcd          # all Flux resources
kubectl get fluxcd-appliers   # all resources in this category
kubectl get all             # now includes Flux resources
```

Each CRD gets exactly three categories:

```
all
fluxcd
fluxcd-appliers
```

The `+kubebuilder:resource` markers were removed from the skipped older
API versions, since they interfere with CRD generation, and the CRDs
were regenerated with `make manifests`.

Part of fluxcd/flux2#5947
