### PR TITLE
Validate HelmRelease kubeconfigs

### DIFF
--- a/docs/spec/v2/helmreleases.md
+++ b/docs/spec/v2/helmreleases.md
@@ -1146,11 +1146,13 @@ stringData:
     # ...omitted for brevity
 ```
 
-**Note:** The KubeConfig should be self-contained and not rely on binaries, the
-environment, or credential files from the helm-controller Pod. This matches the
-constraints of KubeConfigs from current Cluster API providers. KubeConfigs with
-`cmd-path` in them likely won't work without a custom, per-provider installation
-of helm-controller. For more information, see
+**Note:** The KubeConfig must be self-contained and not rely on binaries, the
+environment, or credential files from the helm-controller Pod. KubeConfigs with
+local file references in `certificate-authority`, `tokenFile`,
+`client-certificate`, or `client-key` are rejected. This matches the constraints
+of KubeConfigs from current Cluster API providers. KubeConfigs with `cmd-path`
+in them likely won't work without a custom, per-provider installation of
+helm-controller. For more information, see
 [remote clusters/Cluster-API](#remote-cluster-api-clusters).
 
 #### Secret-less authentication

--- a/internal/kube/config.go
+++ b/internal/kube/config.go
@@ -22,7 +22,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/fluxcd/pkg/runtime/client"
 )
@@ -65,7 +64,7 @@ func ConfigFromSecret(ctx context.Context, secret *corev1.Secret, key string, op
 		return nil, fmt.Errorf("KubeConfig secret '%s' does not contain a '%s' or '%s' key with data", secretName, DefaultKubeConfigSecretKey, DefaultKubeConfigSecretKeyExt)
 	}
 
-	cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
+	cfg, err := client.KubeConfigFromBytes(kubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KubeConfig from secret '%s': %w", secretName, err)
 	}

--- a/internal/kube/config_test.go
+++ b/internal/kube/config_test.go
@@ -47,6 +47,46 @@ users:
   user:
     password: some-password
     username: exp`
+
+	kubeCfgTokenFile = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://1.2.3.4
+  name: development
+contexts:
+- context:
+    cluster: development
+    namespace: frontend
+    user: developer
+  name: dev-frontend
+current-context: dev-frontend
+preferences: {}
+users:
+- name: developer
+  user:
+    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token`
+
+	kubeCfgCertificateAuthorityFile = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: /etc/kubernetes/ca.crt
+    server: https://1.2.3.4
+  name: development
+contexts:
+- context:
+    cluster: development
+    namespace: frontend
+    user: developer
+  name: dev-frontend
+current-context: dev-frontend
+preferences: {}
+users:
+- name: developer
+  user:
+    token: some-token`
 )
 
 func TestConfigFromSecret(t *testing.T) {
@@ -183,6 +223,46 @@ func TestConfigFromSecret(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(got).To(BeNil())
 		g.Expect(err.Error()).To(ContainSubstring("couldn't get version/kind"))
+	})
+
+	t.Run("kubeconfig with file references", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			kubeConfig string
+			wantErr    string
+		}{
+			{
+				name:       "token file",
+				kubeConfig: kubeCfgTokenFile,
+				wantErr:    "references a tokenFile",
+			},
+			{
+				name:       "certificate authority file",
+				kubeConfig: kubeCfgCertificateAuthorityFile,
+				wantErr:    "references a certificate-authority file",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewWithT(t)
+
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "super-secret",
+						Namespace: "vault",
+					},
+					Data: map[string][]byte{
+						DefaultKubeConfigSecretKey: []byte(tt.kubeConfig),
+					},
+				}
+
+				got, err := ConfigFromSecret(t.Context(), secret, "", client.KubeConfigOptions{})
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(got).To(BeNil())
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))
+			})
+		}
 	})
 
 	t.Run("with kubeconfig options", func(t *testing.T) {


### PR DESCRIPTION
Summary:
- Use runtime/client.KubeConfigFromBytes when loading HelmRelease Secret kubeconfigs so local file references are rejected before building rest.Config.
- Document the enforced self-contained kubeconfig requirement.

Testing:
- go test ./internal/kube
- make tidy fmt vet
- make test

Refs:
- https://github.com/fluxcd/pkg/pull/1281