### PR TITLE
Recover from drifted Ready/Released status conditions

### DIFF
--- a/internal/reconcile/atomic_release.go
+++ b/internal/reconcile/atomic_release.go
@@ -372,6 +372,22 @@ func (r *AtomicRelease) actionForState(ctx context.Context, req *Request, state 
 				reason, msgFmt = v2.InstallSucceededReason, fmtInstallSuccess
 			case v2.UpgradeFailedReason:
 				reason, msgFmt = v2.UpgradeSucceededReason, fmtUpgradeSuccess
+			default:
+				// Released may be missing after a failed post-action
+				// condition patch while history was persisted. Derive
+				// the success reason from the last attempted action.
+				action := req.Object.Status.LastAttemptedReleaseAction
+				if action == "" {
+					if cur := req.Object.Status.History.Latest(); cur != nil {
+						action = cur.Action
+					}
+				}
+				switch action {
+				case v2.ReleaseActionInstall:
+					reason, msgFmt = v2.InstallSucceededReason, fmtInstallSuccess
+				case v2.ReleaseActionUpgrade:
+					reason, msgFmt = v2.UpgradeSucceededReason, fmtUpgradeSuccess
+				}
 			}
 			if reason != "" {
 				cur := req.Object.Status.History.Latest()

--- a/internal/reconcile/atomic_release_test.go
+++ b/internal/reconcile/atomic_release_test.go
@@ -1575,6 +1575,65 @@ func TestAtomicRelease_actionForState(t *testing.T) {
 			},
 		},
 		{
+			name: "in-sync release with missing released condition after install",
+			status: func(releases []*helmrelease.Release) v2.HelmReleaseStatus {
+				return v2.HelmReleaseStatus{
+					History: v2.Snapshots{
+						{Version: 1},
+					},
+					LastAttemptedReleaseAction: v2.ReleaseActionInstall,
+					Conditions: []metav1.Condition{
+						*conditions.UnknownCondition(meta.ReadyCondition, meta.ProgressingReason, "Running 'install' action"),
+					},
+				}
+			},
+			state: ReleaseState{Status: ReleaseStatusInSync},
+			want:  nil,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(v2.ReleasedCondition, v2.InstallSucceededReason, "install succeeded"),
+				*conditions.TrueCondition(meta.ReadyCondition, v2.InstallSucceededReason, "install succeeded"),
+			},
+		},
+		{
+			name: "in-sync release with missing released condition after upgrade",
+			status: func(releases []*helmrelease.Release) v2.HelmReleaseStatus {
+				return v2.HelmReleaseStatus{
+					History: v2.Snapshots{
+						{Version: 2},
+					},
+					LastAttemptedReleaseAction: v2.ReleaseActionUpgrade,
+					Conditions: []metav1.Condition{
+						*conditions.UnknownCondition(meta.ReadyCondition, meta.ProgressingReason, "Running 'upgrade' action"),
+					},
+				}
+			},
+			state: ReleaseState{Status: ReleaseStatusInSync},
+			want:  nil,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(v2.ReleasedCondition, v2.UpgradeSucceededReason, "upgrade succeeded"),
+				*conditions.TrueCondition(meta.ReadyCondition, v2.UpgradeSucceededReason, "upgrade succeeded"),
+			},
+		},
+		{
+			name: "in-sync release with missing released condition recovers from history action",
+			status: func(releases []*helmrelease.Release) v2.HelmReleaseStatus {
+				return v2.HelmReleaseStatus{
+					History: v2.Snapshots{
+						{Version: 1, Action: v2.ReleaseActionInstall},
+					},
+					Conditions: []metav1.Condition{
+						*conditions.UnknownCondition(meta.ReadyCondition, meta.ProgressingReason, "Running 'install' action"),
+					},
+				}
+			},
+			state: ReleaseState{Status: ReleaseStatusInSync},
+			want:  nil,
+			assertConditions: []metav1.Condition{
+				*conditions.TrueCondition(v2.ReleasedCondition, v2.InstallSucceededReason, "install succeeded"),
+				*conditions.TrueCondition(meta.ReadyCondition, v2.InstallSucceededReason, "install succeeded"),
+			},
+		},
+		{
 			name:  "locked release triggers unlock action",
 			state: ReleaseState{Status: ReleaseStatusLocked},
 			want:  &Unlock{},


### PR DESCRIPTION
## Description

When a post-action status condition patch failed for a HelmRelease that was just installed or upgraded (e.g. due to version conflicts), but history was successfully persisted, a HelmRelease could be stranded with `Ready=Unknown` while actually being completely installed in the cluster.

Subsequent reconciliations of the HelmRelease would not correct that drift as the pre-existing correction mechanism required a `Released` status condition to exist. However, since that would've been created in the same patch as the missing `Ready` update, that would always fail.

This fix extends the existing correction mechanism to allow for a missing `Released` status condition, in which case it will resort to `status.lastAttemptedReleaseAction` or `status.history` to determine the desired state for `Ready` and `Released`.

Fixes: https://github.com/fluxcd/helm-controller/issues/1409

## Proof of work

The PR was tested against the [reproduction case](https://github.com/peterbuecker-form3/helm-controller-1409-repro) shared in https://github.com/fluxcd/helm-controller/issues/1409#issuecomment-5491059978. The patch was successful in correct the drifted `Ready` and `Released` status conditions. The existing table tests for similar scenarios were extended with new test cases covering the specific situation addressed here.